### PR TITLE
Don't display error dialog when Racer outputs "END" line

### DIFF
--- a/plugin_tooling/src/com/github/rustdt/tooling/ops/RacerCompletionOutputParser.java
+++ b/plugin_tooling/src/com/github/rustdt/tooling/ops/RacerCompletionOutputParser.java
@@ -56,7 +56,9 @@ public abstract class RacerCompletionOutputParser extends AbstractToolOutputPars
 				parsePrefix(line);
 			} else if(line.startsWith("MATCH ")) {
 				proposals.add(parseProposal(line, source));
-			} else {
+			} else if (line.startsWith("END")) {
+                continue;
+            } else {
 				handleMessageParseError(new CommonException("Unknown line format: " + line));
 			}
 			


### PR DESCRIPTION
Don't report error when no result return in racer
