### PR TITLE
Add numbers syntax highlighting support for Rust editor

### DIFF
--- a/plugin_ide.core/src/com/github/rustdt/ide/core/text/RustPartitionScanner.java
+++ b/plugin_ide.core/src/com/github/rustdt/ide/core/text/RustPartitionScanner.java
@@ -10,11 +10,6 @@
  *******************************************************************************/
 package com.github.rustdt.ide.core.text;
 
-import melnorme.lang.ide.core.TextSettings_Actual.LangPartitionTypes;
-import melnorme.lang.ide.core.text.LexingRulePredicateRule;
-import melnorme.lang.ide.core.text.RuleBasedPartitionScannerExt;
-import melnorme.utilbox.collections.ArrayList2;
-
 import org.eclipse.jface.text.rules.IPredicateRule;
 import org.eclipse.jface.text.rules.IToken;
 import org.eclipse.jface.text.rules.PatternRule;
@@ -22,6 +17,12 @@ import org.eclipse.jface.text.rules.Token;
 
 import com.github.rustdt.tooling.lexer.RustCharacterLexingRule;
 import com.github.rustdt.tooling.lexer.RustLifetimeLexingRule;
+import com.github.rustdt.tooling.lexer.RustNumberLexingRule;
+
+import melnorme.lang.ide.core.TextSettings_Actual.LangPartitionTypes;
+import melnorme.lang.ide.core.text.LexingRulePredicateRule;
+import melnorme.lang.ide.core.text.RuleBasedPartitionScannerExt;
+import melnorme.utilbox.collections.ArrayList2;
 
 public class RustPartitionScanner extends RuleBasedPartitionScannerExt {
 	
@@ -41,7 +42,7 @@ public class RustPartitionScanner extends RuleBasedPartitionScannerExt {
 		IToken tkAttribute = new Token(LangPartitionTypes.ATTRIBUTE.getId());
 		rules.add(new PatternRule("#[", "]", tkAttribute, NO_ESCAPE_CHAR, false, true));
 		rules.add(new PatternRule("#![", "]", tkAttribute, NO_ESCAPE_CHAR, false, true));
-		
+
 		rules.add(new LexingRulePredicateRule(LangPartitionTypes.CHARACTER.getId(), new RustCharacterLexingRule()));
 		
 		// Note: this rule must be after character rule
@@ -55,6 +56,7 @@ public class RustPartitionScanner extends RuleBasedPartitionScannerExt {
 		rules.add(new PatternRule("r##\"", "\"##", tkRawString, NO_ESCAPE_CHAR, false, true));
 		rules.add(new PatternRule("br##\"", "\"##", tkRawString, NO_ESCAPE_CHAR, false, true));
 		
+		rules.add(new LexingRulePredicateRule(LangPartitionTypes.NUMBER.getId(), new RustNumberLexingRule()));
 	}
 	
 }

--- a/plugin_ide.core/src/melnorme/lang/ide/core/TextSettings_Actual.java
+++ b/plugin_ide.core/src/melnorme/lang/ide/core/TextSettings_Actual.java
@@ -1,14 +1,15 @@
 package melnorme.lang.ide.core;
 
-import melnorme.lang.ide.core.text.LangDocumentPartitionerSetup;
 import java.util.function.Function;
-import melnorme.utilbox.misc.ArrayUtil;
 
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.rules.IPartitionTokenScanner;
 
 import com.github.rustdt.ide.core.text.RustDocumentSetupParticipant;
 import com.github.rustdt.ide.core.text.RustPartitionScanner;
+
+import melnorme.lang.ide.core.text.LangDocumentPartitionerSetup;
+import melnorme.utilbox.misc.ArrayUtil;
 
 
 public class TextSettings_Actual {
@@ -19,7 +20,7 @@ public class TextSettings_Actual {
 		CODE, 
 		LINE_COMMENT, BLOCK_COMMENT, 
 		DOC_LINE_COMMENT, DOC_BLOCK_COMMENT, 
-		STRING, RAW_STRING, CHARACTER, LIFETIME, ATTRIBUTE;
+		STRING, RAW_STRING, CHARACTER, LIFETIME, ATTRIBUTE, NUMBER;
 		
 		public String getId() {
 			if(ordinal() == 0) {

--- a/plugin_ide.ui/src/com/github/rustdt/ide/ui/editor/RustSourceViewerConfiguration.java
+++ b/plugin_ide.ui/src/com/github/rustdt/ide/ui/editor/RustSourceViewerConfiguration.java
@@ -11,12 +11,6 @@
 package com.github.rustdt.ide.ui.editor;
 
 import static melnorme.utilbox.core.CoreUtil.array;
-import melnorme.lang.ide.core.TextSettings_Actual.LangPartitionTypes;
-import melnorme.lang.ide.ui.LangUIPlugin_Actual;
-import melnorme.lang.ide.ui.editor.structure.AbstractLangStructureEditor;
-import melnorme.lang.ide.ui.text.AbstractLangSourceViewerConfiguration;
-import melnorme.lang.ide.ui.text.completion.ILangCompletionProposalComputer;
-import melnorme.lang.ide.ui.text.completion.LangContentAssistProcessor.ContentAssistCategoriesBuilder;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.IAutoEditStrategy;
@@ -24,12 +18,18 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.information.IInformationProvider;
 import org.eclipse.jface.text.source.ISourceViewer;
 
-import _org.eclipse.cdt.ui.text.IColorManager;
-
 import com.github.rustdt.ide.ui.text.RustAttributeScanner;
 import com.github.rustdt.ide.ui.text.RustCodeScanner;
 import com.github.rustdt.ide.ui.text.RustColorPreferences;
 import com.github.rustdt.ide.ui.text.completion.RustCompletionProposalComputer;
+
+import _org.eclipse.cdt.ui.text.IColorManager;
+import melnorme.lang.ide.core.TextSettings_Actual.LangPartitionTypes;
+import melnorme.lang.ide.ui.LangUIPlugin_Actual;
+import melnorme.lang.ide.ui.editor.structure.AbstractLangStructureEditor;
+import melnorme.lang.ide.ui.text.AbstractLangSourceViewerConfiguration;
+import melnorme.lang.ide.ui.text.completion.ILangCompletionProposalComputer;
+import melnorme.lang.ide.ui.text.completion.LangContentAssistProcessor.ContentAssistCategoriesBuilder;
 
 public class RustSourceViewerConfiguration extends AbstractLangSourceViewerConfiguration {
 	
@@ -62,6 +62,8 @@ public class RustSourceViewerConfiguration extends AbstractLangSourceViewerConfi
 			LangPartitionTypes.LIFETIME.getId());
 		addScanner(new RustAttributeScanner(getTokenStoreFactory()), 
 			LangPartitionTypes.ATTRIBUTE.getId());
+		addScanner(createSingleTokenScanner(RustColorPreferences.NUMBERS.key), 
+				LangPartitionTypes.NUMBER.getId());
 	}
 	
 	@Override

--- a/plugin_ide.ui/src/com/github/rustdt/ide/ui/preferences/SourceColoringConfigurationBlock.java
+++ b/plugin_ide.ui/src/com/github/rustdt/ide/ui/preferences/SourceColoringConfigurationBlock.java
@@ -14,12 +14,12 @@ import static melnorme.utilbox.core.CoreUtil.array;
 
 import java.io.InputStream;
 
-import melnorme.lang.ide.ui.text.coloring.AbstractSourceColoringConfigurationBlock;
-import melnorme.util.swt.jface.LabeledTreeElement;
-
 import org.eclipse.jface.preference.IPreferenceStore;
 
 import com.github.rustdt.ide.ui.text.RustColorPreferences;
+
+import melnorme.lang.ide.ui.text.coloring.AbstractSourceColoringConfigurationBlock;
+import melnorme.util.swt.jface.LabeledTreeElement;
 
 public class SourceColoringConfigurationBlock extends AbstractSourceColoringConfigurationBlock {
 	
@@ -30,6 +30,7 @@ public class SourceColoringConfigurationBlock extends AbstractSourceColoringConf
 			new SourceColoringElement("Keywords - Literals", RustColorPreferences.KEYWORDS_VALUES.key),
 			new SourceColoringElement("Strings", RustColorPreferences.STRINGS.key),
 			new SourceColoringElement("Characters", RustColorPreferences.CHARACTER.key),
+			new SourceColoringElement("Numbers", RustColorPreferences.NUMBERS.key),
 			new SourceColoringElement("Lifetime", RustColorPreferences.LIFETIME.key),
 			new SourceColoringElement("Attribute", RustColorPreferences.ATTRIBUTE.key)
 		)),

--- a/plugin_ide.ui/src/com/github/rustdt/ide/ui/text/RustColorPreferences.java
+++ b/plugin_ide.ui/src/com/github/rustdt/ide/ui/text/RustColorPreferences.java
@@ -32,7 +32,8 @@ public interface RustColorPreferences {
 		true, new RGB(0xB7, 0x65, 0x14), false, false, false);
 	ColoringItemPreference ATTRIBUTE = new ColoringItemPreference(PREFIX + LangPartitionTypes.ATTRIBUTE,
 		true, new RGB(0xC8, 0x28, 0x29), false, false, false);
-	
+	ColoringItemPreference NUMBERS = new ColoringItemPreference(PREFIX + LangPartitionTypes.NUMBER,
+			true, new RGB(0x70, 0x94, 0xFF), false, false, false);	
 	
 	ColoringItemPreference DEFAULT = new ColoringItemPreference(PREFIX + "default",
 		true, new RGB(0, 0, 0), false, false, false);

--- a/plugin_tooling/src-lang/melnorme/lang/tooling/parser/lexer/StringCharacterReader.java
+++ b/plugin_tooling/src-lang/melnorme/lang/tooling/parser/lexer/StringCharacterReader.java
@@ -29,7 +29,7 @@ public class StringCharacterReader implements ICharacterReader {
 	
 	@Override
 	public int lookahead() {
-		if(offset >= source.length()) {
+		if(offset >= source.length() || offset < 0) {
 			return -1;
 		}
 		return source.charAt(offset);

--- a/plugin_tooling/src-tests/com/github/rustdt/tooling/lexer/LexingRulesTest.java
+++ b/plugin_tooling/src-tests/com/github/rustdt/tooling/lexer/LexingRulesTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bruno Medeiros and other Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Bruno Medeiros - initial API and implementation
+ *     Konstantin Salikhov - test cases for lexing rule
+ *******************************************************************************/
+package com.github.rustdt.tooling.lexer;
+
+import org.junit.Test;
+
+import melnorme.lang.tests.CommonToolingTest;
+import melnorme.lang.tooling.parser.lexer.ILexingRule;
+import melnorme.lang.tooling.parser.lexer.StringCharacterReader;
+
+public class LexingRulesTest extends CommonToolingTest {
+
+	public static void testRule(ILexingRule lexRule, String source, int expectedTokenLength) {
+		StringCharacterReader reader = new StringCharacterReader(source);
+		boolean isMatch = lexRule.evaluate(reader);
+
+		assertEquals(isMatch, expectedTokenLength > 0);
+		if (isMatch) {
+			assertEquals(reader.getOffset(), expectedTokenLength);
+		}
+	}
+
+	public static void testNumberRule(String source, int expectedTokenLength) {
+		testRule(new RustNumberLexingRule(), source, expectedTokenLength);
+	}
+
+	@Test
+	public void testNumberLexingRuleValid() throws Exception {
+		testNumberLexingRuleValid$();
+	}
+
+	public void testNumberLexingRuleValid$() throws Exception {
+		testNumberRule("-1.01", 5);
+		testNumberRule("-1", 2);
+
+		testNumberRule("0", 1);
+		testNumberRule("123", 3);
+		testNumberRule("123", 3);
+		testNumberRule("1u8", 3);
+		testNumberRule("2u16", 4);
+		testNumberRule("3u32", 4);
+		testNumberRule("4u64", 4);
+		testNumberRule("1i8", 3);
+		testNumberRule("2i16", 4);
+		testNumberRule("3i32", 4);
+		testNumberRule("4i64", 4);
+
+		testNumberRule("123.0", 5);
+		testNumberRule("123.1f32", 8);
+		testNumberRule("123.2f64", 8);
+
+		testNumberRule("0xFF", 4);
+		testNumberRule("0b11", 4);
+		testNumberRule("0o77", 4);
+
+		testNumberRule("0xFFu16", 7);
+		testNumberRule("0b11u16", 7);
+		testNumberRule("0o77u16", 7);
+		testNumberRule("0xFFu32", 7);
+		testNumberRule("0b11u32", 7);
+		testNumberRule("0o77u32", 7);
+		testNumberRule("0xFFu64", 7);
+		testNumberRule("0b11u64", 7);
+		testNumberRule("0o77u64", 7);
+		testNumberRule("123..", 3);
+		testNumberRule("123,", 3);
+		testNumberRule("10_20_30", 8);
+	}
+
+	@Test
+	public void testNumberLexingRuleInvalid() throws Exception {
+		testNumberLexingRuleInvalid$();
+	}
+
+	public void testNumberLexingRuleInvalid$() throws Exception {
+		testNumberRule("\"5000\"", 0);
+		testNumberRule("xxx", 0);
+		testNumberRule("", 0);
+		testNumberRule("123xxx", 0);
+		testNumberRule("123.4xxx", 0);
+		testNumberRule("xxx123", 0);
+		testNumberRule("0x0.2", 0);
+		testNumberRule("0o0.2", 0);
+		testNumberRule("0b0.2", 0);
+		testNumberRule("0.2u32", 0);
+		testNumberRule("0x0xFF", 0);
+	}
+}

--- a/plugin_tooling/src/com/github/rustdt/tooling/lexer/RustNumberLexingRule.java
+++ b/plugin_tooling/src/com/github/rustdt/tooling/lexer/RustNumberLexingRule.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2015 Bruno Medeiros and other Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Konstantin Salikhov - number lexing rule implementation
+ *******************************************************************************/
+package com.github.rustdt.tooling.lexer;
+
+import melnorme.lang.tooling.parser.lexer.CommonLexingRule;
+import melnorme.lang.tooling.parser.lexer.ICharacterReader;
+import melnorme.lang.tooling.parser.lexer.ILexingRule;
+
+public class RustNumberLexingRule extends CommonLexingRule implements ILexingRule {
+
+	@Override
+	public boolean evaluate(ICharacterReader reader) {
+
+		if (!checkPrefix(reader)) {
+			return false;
+		}
+
+		boolean hasPrefix = consumeIntPrefix(reader);
+		while (hasPrefix && reader.consume('_')) {
+			// JUST SKIP THEM
+		}
+
+		if (!consumeDigit(reader)) {
+			return false;
+		}
+
+		while (consumeDigit(reader) || reader.consume('_')) {
+			// JUST SKIP THEM
+		}
+
+		if (!consumeIntSuffix(reader)) {
+			if (reader.consume('.')) {
+				if (reader.lookahead() == '.') {
+					reader.unread();
+				} else {
+					if (!consumeDigit(reader)) {
+						return false;
+					}
+					while (consumeDigit(reader) || reader.consume('_')) {
+						// JUST SKIP THEM
+					}
+					consumeFloatSuffix(reader);
+				}
+			}
+		}
+
+		int postfix = reader.lookahead();
+		if (Character.isAlphabetic(postfix)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private static boolean checkPrefix(ICharacterReader reader) {
+		int prefix; 
+		int behind = 0;
+		while(true) {
+			prefix = reader.lookahead();
+			if (Character.isDigit(prefix)) {
+				reader.unread();
+				behind++;
+				continue;
+			}
+			break;
+		}
+		
+		for (int i = 0; i < behind; i++) {
+			reader.read();
+		}
+		
+		if (Character.isAlphabetic(prefix) || '_' == prefix) {
+			return false;
+		}
+		
+		return true;
+	}
+
+	private static boolean consumeDigit(ICharacterReader reader) {
+		int c = reader.lookahead();
+		if (c >= '0' && c <= '9') {
+			reader.read();
+			return true;
+		}
+		return false;
+	}
+
+	private static boolean consumeIntPrefix(ICharacterReader reader) {
+		if (reader.consume('0')) {
+			if (reader.consume('x') || reader.consume('o') || reader.consume('b')) {
+				return true;
+			} else {
+				reader.unread();
+			}
+		}
+		return false;
+	}
+
+	private static boolean consumeIntSuffix(ICharacterReader reader) {
+		if (reader.consume('i') || reader.consume('u')) {
+			if (reader.consume('8')) {
+				return true;
+			} else if (reader.consume('1')) {
+				if (reader.consume('6')) {
+					return true;
+				} else {
+					reader.unread();
+					reader.unread();
+				}
+			} else if (reader.consume('3')) {
+				if (reader.consume('2')) {
+					return true;
+				} else {
+					reader.unread();
+					reader.unread();
+				}
+			} else if (reader.consume('6')) {
+				if (reader.consume('4')) {
+					return true;
+				} else {
+					reader.unread();
+					reader.unread();
+				}
+			} else {
+				reader.unread();
+			}
+		}
+		return false;
+	}
+
+	private static boolean consumeFloatSuffix(ICharacterReader reader) {
+		if (reader.consume('f')) {
+			if (reader.consume('3')) {
+				if (reader.consume('2')) {
+					return true;
+				} else {
+					reader.unread();
+					reader.unread();
+				}
+			} else if (reader.consume('6')) {
+				if (reader.consume('4')) {
+					return true;
+				} else {
+					reader.unread();
+					reader.unread();
+				}
+			} else {
+				reader.unread();
+			}
+		}
+		return false;
+	}
+
+}


### PR DESCRIPTION
Hi Bruno!

I've found an issue #55 is still Open, so I've added some improvements to rust editor syntax coloring that are related to number literals - just to practice in eclipse plugin programming.

You could merge it into RustDT if you'll find my changes useful.

Thank you for your great rust eclipse plugin!
