### PR TITLE
Do not show error dialog if autocompletion fails

### DIFF
--- a/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/text/completion/LangContentAssistProcessor.java
+++ b/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/text/completion/LangContentAssistProcessor.java
@@ -214,7 +214,6 @@ public class LangContentAssistProcessor extends ContenAssistProcessorExt {
 		try {
 			proposals = cat.computeCompletionProposals(context);
 		} catch(CommonException ce) {
-			handleExceptionInUI(ce);
 			setAndDisplayErrorMessage(ce.getMessage());
 			return null;
 		}


### PR DESCRIPTION
This is very great IDE but error dialogs while you type your code just ruin the whole thing.

It is sooo annoying!!!!! Autocompletion should NEVER cause any dialogs, if it fails let it fail, I don't care, I will type it myself.

Honestly, I didn't actually tested this commit, I just removed the line which I believe is causing this dialog. Maybe there is a better way to remove these dialogs.

Thanks for this great IDE, if there will be no stupid dialogs it would be just awesome.

P.S. dialog says "No target found", I couldn't reproduce it right now but I have seen it so many times.
