### PR TITLE
Add link to Rust sources

### DIFF
--- a/documentation/UserGuide.md
+++ b/documentation/UserGuide.md
@@ -8,7 +8,7 @@ what overall functionalities are available.
 A [Rust installation](http://www.rust-lang.org/install.html) is required for most IDE functionality. The path to the installation should be configured in the `Rust` preference page, accessed from the menu `Window / Preferences`.
 
 Additionally, for functionality such as code completion, you will need:
- * The Rust sources package. This package is not included in the Rust intallation, so it must be obtained separately (see [this Rust bug](https://github.com/rust-lang/rust/issues/19535)). Configure the `Rust 'src' Directory` to point to the 'src' directory of this package.
+ * The [Rust sources package](https://www.rust-lang.org/downloads.html). This package is not included in the Rust intallation, so it must be obtained separately (see [this Rust bug](https://github.com/rust-lang/rust/issues/19535)). Configure the `Rust 'src' Directory` to point to the 'src' directory of this package.
  * The [Racer](https://github.com/phildawes/racer) tool. It is recommended to use the "Download" button in the preference page to have RustDT automatically download Racer (this will use `cargo install` - as such the Rust installation must already be configured).
  
 For functionality such as Outline/Quick-Outline and on-the-fly parsing errors, you will need the [Rainicorn](https://github.com/RustDT/Rainicorn) tool. Same as with Racer, you can use the "Download" button to install it.


### PR DESCRIPTION
Add a download link to rust sources so users don't need to search for it. Also prevent users from asking on https://github.com/rust-lang/rust/issues/19535
