### PR TITLE
Fixes syntax highlighting for the character literal '\"'

### DIFF
--- a/plugin_tooling/src-lang/melnorme/lang/tooling/parser/lexer/CharacterLexingRule.java
+++ b/plugin_tooling/src-lang/melnorme/lang/tooling/parser/lexer/CharacterLexingRule.java
@@ -35,7 +35,8 @@ public class CharacterLexingRule extends LexingUtils implements IPredicateLexing
 	
 	protected boolean consumeBody(ICharacterReader reader) {
 		if(reader.tryConsume((char) 0x5c)) {
-			return reader.tryConsume('\'') || consumeCommonEscape(reader) || consumeUnicodeEscapeSequence(reader);
+			return reader.tryConsume('\'') || reader.tryConsume('\"') ||
+				   consumeCommonEscape(reader) || consumeUnicodeEscapeSequence(reader);
 		};
 		
 		if(reader.lookaheadIsEOS() || reader.lookahead() == '\'') {


### PR DESCRIPTION
\" is a valid escape sequence for rust char literals.
This patch makes CharacterLexing aware of the sequence '\"'.
