### PR TITLE
Do not report source code parsing errors when invoking rustfmt

### DIFF
--- a/plugin_ide.ui/src/com/github/rustdt/ide/ui/editor/RustFmtOperation.java
+++ b/plugin_ide.ui/src/com/github/rustdt/ide/ui/editor/RustFmtOperation.java
@@ -11,6 +11,9 @@
 package com.github.rustdt.ide.ui.editor;
 
 import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.ui.texteditor.ITextEditor;
@@ -30,6 +33,8 @@ import melnorme.utilbox.misc.StringUtil;
 import melnorme.utilbox.process.ExternalProcessHelper.ExternalProcessResult;
 
 public class RustFmtOperation extends AbstractEditorOperation2<String> {
+	private static final int NO_ERRORS = 0;
+	private static final int PARSING_ERRORS = 2;
 	
 	protected final ToolManager toolMgr = LangCore.getToolManager();
 	
@@ -61,17 +66,19 @@ public class RustFmtOperation extends AbstractEditorOperation2<String> {
 		ExternalProcessResult result = toolMgr.runEngineTool(pb, input, monitor);
 		int exitValue = result.exitValue;
 		
-		if(exitValue != 0) {
-			String stdErr = result.getStdErrBytes().toUtf8String();
-			String firstStderrLine = StringUtil.splitString(stdErr, '\n')[0].trim();
-			
-			statusErrorMessage = ToolingMessages.PROCESS_CompletedWithNonZeroValue("rustfmt", exitValue) + "\n" +
-					firstStderrLine;
-			return null;
+		switch(exitValue) {
+			case NO_ERRORS:
+				// formatted file is in stdout
+				return result.getStdOutBytes().toUtf8String();
+			case PARSING_ERRORS:
+				return input;
+			default:
+				String stdErr = result.getStdErrBytes().toUtf8String();
+				String firstStderrLine = StringUtil.splitString(stdErr, '\n')[0].trim();
+				
+				statusErrorMessage = ToolingMessages.PROCESS_CompletedWithNonZeroValue("rustfmt", exitValue) + "\n" + firstStderrLine;
+				return null;
 		}
-		
-		// formatted file is in stdout
-		return result.getStdOutBytes().toUtf8String();
 	}
 	
 	@Override

--- a/plugin_ide.ui/src/com/github/rustdt/ide/ui/editor/RustFmtOperation.java
+++ b/plugin_ide.ui/src/com/github/rustdt/ide/ui/editor/RustFmtOperation.java
@@ -11,9 +11,6 @@
 package com.github.rustdt.ide.ui.editor;
 
 import java.nio.file.Path;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.ui.texteditor.ITextEditor;


### PR DESCRIPTION
When `rustfmt` is invoked on a broken source file, an error popup is spawned. This behavior is inconsistent with that of existing formatters (e.g. the default Java code formatter) and can be really annoying when working with auto-format on save active.

Merging this pull request will stop reporting source code errors and leave the source file as is instead. Other errors, e.g. parsing errors of `rustfmt.toml` will still be reported.
