### PR TITLE
Use HTTPS for Eclipse update site

### DIFF
--- a/documentation/Installation.md
+++ b/documentation/Installation.md
@@ -8,7 +8,7 @@
  1. Use your existing Eclipse, or download a new Eclipse package from http://www.eclipse.org/downloads/. 
   * For an Eclipse package without any other IDEs or extras (such a VCS tools), download the ["Platform Runtime Binary"](http://archive.eclipse.org/eclipse/downloads/drops4/R-4.5-201506032000/#PlatformRuntime). 
  1. Start Eclipse, go to `Help -> Install New Software...`
- 1. Click the `Add...` button to add a new update site, enter the URL: **http://rustdt.github.io/releases/** in the Location field, click OK.
+ 1. Click the `Add...` button to add a new update site, enter the URL: **https://rustdt.github.io/releases/** in the Location field, click OK.
  1. Select the recently added update site in the `Work with:` dropdown. Type `RustDT` in the filter box. Now the RustDT feature should appear below.
  1. Select the `RustDT` feature, and complete the wizard. 
   * RustDT dependencies such as CDT will automatically be added during installation.


### PR DESCRIPTION
Update the installation documentation to use HTTPS for the Eclipse update site.

This adds an extra layer of security for the update/installation system. As most Eclipse users expect third party extensions to be unsigned there is a tendency to accept the warning and thus allowing arbitrary code executions.

May I suggest that the docs also get updated with information on expecting a signature check prompt and the signatures fingerprint to check against?
