### PR TITLE
Try index on racer fail

### DIFF
--- a/documentation/ChangeLog.md
+++ b/documentation/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ### (NextVersion)
  * Added support for Open Type (`Ctrl+Shift+T`)
+ * Matches that were not found by Racer can now be found by the newly created index
  * Fixed: Build Target's append environment variables might not replace variables correctly in Windows, due to case issues.
 
 ### 0.8.0

--- a/documentation/ChangeLog.md
+++ b/documentation/ChangeLog.md
@@ -1,6 +1,7 @@
 ## release ChangeLog
 
 ### (NextVersion)
+ * Added support for Open Type (`Ctrl+Shift+T`)
  * Fixed: Build Target's append environment variables might not replace variables correctly in Windows, due to case issues.
 
 ### 0.8.0

--- a/plugin_ide.core.tests/src-lang/melnorme/lang/ide/core/engine/ModelReconcilationTest.java
+++ b/plugin_ide.core.tests/src-lang/melnorme/lang/ide/core/engine/ModelReconcilationTest.java
@@ -31,7 +31,6 @@ import org.eclipse.jface.text.IDocument;
 import org.junit.Test;
 
 import melnorme.lang.ide.core.engine.SourceModelManager.StructureModelRegistration;
-import melnorme.lang.ide.core.engine.SourceModelManager.StructureUpdateTask;
 import melnorme.lang.ide.core.engine.StructureModelTest.FixtureSourceModelManager;
 import melnorme.lang.ide.core.operations.build.BuildManager;
 import melnorme.lang.ide.core.operations.build.ProjectBuildInfo;

--- a/plugin_ide.core.tests/src-lang/melnorme/lang/ide/core/engine/StructureModelTest.java
+++ b/plugin_ide.core.tests/src-lang/melnorme/lang/ide/core/engine/StructureModelTest.java
@@ -10,7 +10,6 @@ package melnorme.lang.ide.core.engine;
  *     Bruno Medeiros - initial API and implementation
  *******************************************************************************/
 
-
 import static melnorme.utilbox.core.Assert.AssertNamespace.assertFail;
 import static melnorme.utilbox.core.Assert.AssertNamespace.assertTrue;
 
@@ -20,17 +19,17 @@ import java.util.function.Function;
 import org.eclipse.jface.text.Document;
 import org.junit.Test;
 
-import melnorme.lang.ide.core.engine.SourceModelManager.StructureModelRegistration;
 import melnorme.lang.ide.core.engine.SourceModelManager.StructureInfo;
-import melnorme.lang.ide.core.engine.SourceModelManager.StructureUpdateTask;
+import melnorme.lang.ide.core.engine.SourceModelManager.StructureModelRegistration;
 import melnorme.lang.ide.core.tests.CommonCoreTest;
 import melnorme.lang.tooling.LocationKey;
 import melnorme.lang.tooling.common.ParserError;
 import melnorme.lang.tooling.structure.SourceFileStructure;
+import melnorme.utilbox.collections.ArrayList2;
 import melnorme.utilbox.collections.Indexable;
 import melnorme.utilbox.concurrency.OperationCancellation;
-import melnorme.utilbox.core.CommonException;
 import melnorme.utilbox.core.Assert.AssertFailedException;
+import melnorme.utilbox.core.CommonException;
 import melnorme.utilbox.core.fntypes.OperationCallable;
 import melnorme.utilbox.ownership.StrictDisposable;
 import melnorme.utilbox.tests.TestsWorkingDir;
@@ -179,7 +178,7 @@ public class StructureModelTest extends CommonCoreTest {
 			} catch(InterruptedException e) {
 				throw new OperationCancellation();
 			}
-			return null;			
+			return new SourceFileStructure(null, ArrayList2.create(), ArrayList2.create());
 		});
 		
 		StructureModelRegistration registration = mgr.connectStructureUpdates(key, doc, 

--- a/plugin_ide.core/src-lang/melnorme/lang/ide/core/AbstractLangCore.java
+++ b/plugin_ide.core/src-lang/melnorme/lang/ide/core/AbstractLangCore.java
@@ -13,6 +13,7 @@ package melnorme.lang.ide.core;
 import static melnorme.utilbox.core.Assert.AssertNamespace.assertNotNull;
 
 import melnorme.lang.ide.core.engine.ILanguageServerHandler;
+import melnorme.lang.ide.core.engine.IndexManager;
 import melnorme.lang.ide.core.engine.SourceModelManager;
 import melnorme.lang.ide.core.operations.ToolManager;
 import melnorme.lang.ide.core.operations.build.BuildManager;
@@ -37,6 +38,7 @@ public abstract class AbstractLangCore extends LoggingCore {
 	protected final BundleModelManager<? extends LangBundleModel> bundleManager;
 	protected final BuildManager buildManager;
 	protected final SourceModelManager sourceModelManager;
+	protected final IndexManager indexManager;
 	
 	public AbstractLangCore(ILogHandler logHandler) {
 		instance = (LangCore) this;
@@ -49,12 +51,14 @@ public abstract class AbstractLangCore extends LoggingCore {
 		bundleManager = assertNotNull(LangCore_Actual.createBundleModelManager());
 		buildManager = assertNotNull(createBuildManager());
 		sourceModelManager = assertNotNull(LangCore_Actual.createSourceModelManager());
+		indexManager = assertNotNull(LangCore_Actual.createIndexManager());
 	}
 	
 	protected void shutdown() {
 		buildManager.dispose();
 		bundleManager.shutdownManager();
 		sourceModelManager.dispose();
+		indexManager.dispose();
 		languageServerHandler.dispose();
 		toolManager.shutdownNow();
 	}
@@ -80,6 +84,7 @@ public abstract class AbstractLangCore extends LoggingCore {
 	public static BundleModelManager<? extends LangBundleModel> getBundleModelManager() {
 		return instance.bundleManager;
 	}
+	
 	public static LangBundleModel getBundleModel() {
 		return getBundleModelManager().getModel();
 	}
@@ -98,6 +103,10 @@ public abstract class AbstractLangCore extends LoggingCore {
 	
 	public static ILanguageServerHandler getLanguageServerHandler() {
 		return instance.languageServerHandler;
+	}
+	
+	public static IndexManager getIndexManager() {
+		return instance.indexManager;
 	}
 	
 	/* -----------------  ----------------- */
@@ -124,6 +133,7 @@ class LoggingCore {
 	public static void logError(String message) {
 		log().logError(message);
 	}
+	
 	/** Logs an error status with given message and given throwable. */
 	public static void logError(String message, Throwable throwable) {
 		log().logError(message, throwable);
@@ -133,6 +143,7 @@ class LoggingCore {
 	public static void logWarning(String message) {
 		log().logWarning(message);
 	}
+	
 	/** Logs a warning status with given message and given throwable. */
 	public static void logWarning(String message, Throwable throwable) {
 		log().logWarning(message, throwable);

--- a/plugin_ide.core/src-lang/melnorme/lang/ide/core/engine/DocumentReconcileManager.java
+++ b/plugin_ide.core/src-lang/melnorme/lang/ide/core/engine/DocumentReconcileManager.java
@@ -26,7 +26,6 @@ import org.eclipse.jface.text.ISynchronizable;
 
 import melnorme.lang.ide.core.LangCore;
 import melnorme.lang.ide.core.engine.SourceModelManager.StructureInfo;
-import melnorme.lang.ide.core.engine.SourceModelManager.StructureUpdateTask;
 import melnorme.lang.ide.core.operations.build.BuildManager;
 import melnorme.lang.ide.core.utils.CoreExecutors;
 import melnorme.lang.ide.core.utils.DefaultBufferListener;

--- a/plugin_ide.core/src-lang/melnorme/lang/ide/core/engine/IndexManager.java
+++ b/plugin_ide.core/src-lang/melnorme/lang/ide/core/engine/IndexManager.java
@@ -1,0 +1,9 @@
+package melnorme.lang.ide.core.engine;
+
+import java.util.List;
+
+import melnorme.lang.tooling.structure.StructureElement;
+
+public abstract class IndexManager extends AbstractAgentManager {
+	public abstract List<StructureElement> getGlobalSourceStructure();
+}

--- a/plugin_ide.core/src-lang/melnorme/lang/ide/core/engine/ProjectReconcileManager.java
+++ b/plugin_ide.core/src-lang/melnorme/lang/ide/core/engine/ProjectReconcileManager.java
@@ -16,13 +16,13 @@ import java.util.HashMap;
 
 import org.eclipse.core.resources.IProject;
 
-import melnorme.lang.ide.core.engine.SourceModelManager.StructureUpdateTask;
 import melnorme.lang.ide.core.operations.ILangOperationsListener_Default.IToolOperationMonitor;
 import melnorme.lang.ide.core.operations.ILangOperationsListener_Default.ProcessStartKind;
 import melnorme.lang.ide.core.operations.build.BuildManager;
 import melnorme.lang.ide.core.operations.build.BuildTarget;
 import melnorme.lang.tooling.common.ops.IOperationMonitor.NullOperationMonitor;
 import melnorme.utilbox.collections.ArrayList2;
+import melnorme.utilbox.concurrency.CompletableResult.CompletableLatch;
 import melnorme.utilbox.concurrency.CompletableResult.CompletableLatch;
 import melnorme.utilbox.concurrency.ICancelMonitor;
 import melnorme.utilbox.concurrency.ICommonExecutor;
@@ -105,7 +105,7 @@ abstract class AbstractProjectReconcileManager {
 			fileSaveLatch.awaitResult();
 			
 			if(structureUpdateTask != null) {
-				structureUpdateTask.structureInfo.awaitUpdatedData();
+				structureUpdateTask.awaitUpdatedData();
 			}
 		}
 		

--- a/plugin_ide.core/src-lang/melnorme/lang/ide/core/engine/SourceModelManager.java
+++ b/plugin_ide.core/src-lang/melnorme/lang/ide/core/engine/SourceModelManager.java
@@ -16,15 +16,11 @@ import static melnorme.utilbox.core.CoreUtil.areEqual;
 
 import org.eclipse.jface.text.IDocument;
 
-import melnorme.lang.ide.core.LangCore;
 import melnorme.lang.ide.core.engine.DocumentReconcileManager.DocumentReconcileConnection;
 import melnorme.lang.tooling.LocationKey;
 import melnorme.lang.tooling.structure.SourceFileStructure;
-import melnorme.lang.utils.concurrency.ConcurrentlyDerivedData;
-import melnorme.lang.utils.concurrency.ConcurrentlyDerivedData.DataUpdateTask;
 import melnorme.lang.utils.concurrency.SynchronizedEntryMap;
 import melnorme.utilbox.concurrency.OperationCancellation;
-import melnorme.utilbox.core.CommonException;
 import melnorme.utilbox.core.fntypes.CommonResult;
 import melnorme.utilbox.fields.ListenerListHelper;
 import melnorme.utilbox.misc.Location;
@@ -122,13 +118,12 @@ public abstract class SourceModelManager extends AbstractAgentManager {
 	
 	/* -----------------  ----------------- */
 	
-	public class StructureInfo extends ConcurrentlyDerivedData<CommonResult<SourceFileStructure>, StructureInfo> {
+	public class StructureInfo extends StructureResult<StructureInfo> {
 		
 		protected final LocationKey key2;
 		
 		protected IDocument document = null;
 		protected DocumentReconcileConnection reconcileConnection = null;
-		
 		
 		public StructureInfo(LocationKey key) {
 			super();
@@ -245,42 +240,13 @@ public abstract class SourceModelManager extends AbstractAgentManager {
 		return new DisconnectUpdatesTask(structureInfo);
 	}
 	
-	public static abstract class StructureUpdateTask extends DataUpdateTask<CommonResult<SourceFileStructure>> {
-		
-		protected final StructureInfo structureInfo;
-		
-		public StructureUpdateTask(StructureInfo structureInfo) {
-			super(structureInfo, structureInfo.getKey2().toString());
-			this.structureInfo = structureInfo;
-		}
-		
-		@Override
-		protected void handleRuntimeException(RuntimeException e) {
-			LangCore.logInternalError(e);
-		}
-		
-		@Override
-		protected final CommonResult<SourceFileStructure> createNewData() throws OperationCancellation {
-			try {
-				return new CommonResult<>(doCreateNewData());
-			} catch(CommonException e) {
-				return new CommonResult<>(null, e);
-			}
-		}
-		
-		protected abstract SourceFileStructure doCreateNewData() throws CommonException, OperationCancellation;
-		
-	}
-	
 	public static class DisconnectUpdatesTask extends StructureUpdateTask {
-		
 		public DisconnectUpdatesTask(StructureInfo structureInfo) {
 			super(structureInfo);
 		}
 		
 		@Override
 		protected SourceFileStructure doCreateNewData() throws OperationCancellation {
-			Location location = structureInfo.getLocation();
 			if(location != null) {
 				handleDisconnectForLocation(location);
 			} else {
@@ -299,7 +265,6 @@ public abstract class SourceModelManager extends AbstractAgentManager {
 		}
 		
 	}
-	
 	
 	/* ----------------- Listeners ----------------- */
 	

--- a/plugin_ide.core/src-lang/melnorme/lang/ide/core/engine/StructureResult.java
+++ b/plugin_ide.core/src-lang/melnorme/lang/ide/core/engine/StructureResult.java
@@ -1,0 +1,14 @@
+package melnorme.lang.ide.core.engine;
+
+import java.util.Optional;
+
+import melnorme.lang.tooling.structure.SourceFileStructure;
+import melnorme.lang.utils.concurrency.ConcurrentlyDerivedData;
+import melnorme.utilbox.core.fntypes.CommonResult;
+
+public abstract class StructureResult<SELF> extends ConcurrentlyDerivedData<CommonResult<SourceFileStructure>, SELF> {
+	public Optional<SourceFileStructure> getStructure() {
+		return Optional.ofNullable(getStoredData())
+			.map(CommonResult::getOrNull);
+	}
+}

--- a/plugin_ide.core/src-lang/melnorme/lang/ide/core/engine/StructureUpdateTask.java
+++ b/plugin_ide.core/src-lang/melnorme/lang/ide/core/engine/StructureUpdateTask.java
@@ -1,0 +1,55 @@
+package melnorme.lang.ide.core.engine;
+
+import java.util.Optional;
+
+import melnorme.lang.ide.core.LangCore;
+import melnorme.lang.ide.core.engine.SourceModelManager.StructureInfo;
+import melnorme.lang.tooling.structure.SourceFileStructure;
+import melnorme.lang.utils.concurrency.ConcurrentlyDerivedData.DataUpdateTask;
+import melnorme.utilbox.collections.Indexable;
+import melnorme.utilbox.concurrency.OperationCancellation;
+import melnorme.utilbox.core.CommonException;
+import melnorme.utilbox.core.fntypes.CommonResult;
+import melnorme.utilbox.misc.Location;
+
+public abstract class StructureUpdateTask extends DataUpdateTask<CommonResult<SourceFileStructure>> {
+	private final StructureResult<?> structureResult;
+	protected final Location location;
+	
+	public StructureUpdateTask(StructureInfo structureInfo) {
+		this(structureInfo, structureInfo.getKey2().getLocation());
+	}
+	
+	public StructureUpdateTask(StructureResult<?> structureResult, Location location) {
+		super(structureResult, location != null ? location.toString() : null);
+		this.structureResult = structureResult;
+		this.location = location;
+	}
+	
+	
+	@Override
+	protected void handleRuntimeException(RuntimeException e) {
+		LangCore.logInternalError(e);
+	}
+	
+	@Override
+	protected final CommonResult<SourceFileStructure> createNewData() throws OperationCancellation {
+		try {
+			SourceFileStructure newStructure = doCreateNewData();
+			boolean keepPreviousStructure =
+				!newStructure.getParserProblems().isEmpty() && newStructure.getChildren().isEmpty();
+			if(keepPreviousStructure) {
+				Optional<SourceFileStructure> previousStructure = structureResult.getStructure();
+				newStructure = previousStructure.isPresent()
+					? new SourceFileStructure(location, previousStructure.get().cloneSubTree(),
+						newStructure.getParserProblems())
+					: new SourceFileStructure(location, Indexable.EMPTY_INDEXABLE, Indexable.EMPTY_INDEXABLE);
+			}
+			return new CommonResult<>(newStructure);
+		} catch(CommonException e) {
+			return new CommonResult<>(null, e);
+		}
+	}
+	
+	protected abstract SourceFileStructure doCreateNewData() throws CommonException, OperationCancellation;
+}

--- a/plugin_ide.core/src/com/github/rustdt/ide/core/engine/RustIndexManager.java
+++ b/plugin_ide.core/src/com/github/rustdt/ide/core/engine/RustIndexManager.java
@@ -1,0 +1,140 @@
+package com.github.rustdt.ide.core.engine;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.ResourcesPlugin;
+
+import com.github.rustdt.ide.core.engine.RustStructureUpdateTask.RustStructureFileRemovedTask;
+import com.github.rustdt.ide.core.engine.RustStructureUpdateTask.RustStructureSourceTouchedTask;
+import com.github.rustdt.ide.core.engine.RustStructureUpdateTask.SourceProvider;
+
+import melnorme.lang.ide.core.LangCore;
+import melnorme.lang.ide.core.engine.IndexManager;
+import melnorme.lang.ide.core.engine.StructureResult;
+import melnorme.lang.ide.core.utils.ResourceUtils;
+import melnorme.lang.tooling.structure.GlobalSourceStructure;
+import melnorme.lang.tooling.structure.StructureElement;
+import melnorme.utilbox.misc.FileUtil;
+import melnorme.utilbox.misc.Location;
+import melnorme.utilbox.misc.StringUtil;
+
+public class RustIndexManager extends IndexManager {
+	private final GlobalSourceStructure sourceStructure = new GlobalSourceStructure();
+	
+	private final Map<Location, StructureInfo> startedIndexUpdates = new ConcurrentHashMap<>();
+	
+	private final IResourceChangeListener resourcesChanged = this::processResourceChangeEvent;
+	
+	public RustIndexManager() {
+		evaluateGlobalSourceStructure();
+		listenToUpdatesOfGlobalSourceStructure();
+		asOwner().bind(this::stopListeningToUpdatesOfGlobalSourceStructure);
+	}
+	
+	private void evaluateGlobalSourceStructure() {
+		try {
+			ResourcesPlugin.getWorkspace().getRoot().accept(RustIndexManager.this::addResource);
+		} catch(Exception e) {
+			LangCore.logError("Could not initialize Rust type index", e);
+		}
+	}
+	
+	private boolean addResource(IResource resource) {
+		convertToRustFileLocation(resource).ifPresent(this::enqueueFileTouchedTask);
+		return true;
+	}
+	
+	private void listenToUpdatesOfGlobalSourceStructure() {
+		ResourcesPlugin.getWorkspace().addResourceChangeListener(resourcesChanged, IResourceChangeEvent.POST_CHANGE);
+	}
+	
+	private void stopListeningToUpdatesOfGlobalSourceStructure() {
+		ResourcesPlugin.getWorkspace().removeResourceChangeListener(resourcesChanged);
+	}
+	
+	private void processResourceChangeEvent(IResourceChangeEvent event) {
+		try {
+			event.getDelta().accept(this::applyResourceDelta);
+		} catch(Exception e) {
+			LangCore.logError("Could not update Rust type index", e);
+		}
+	}
+	
+	private boolean applyResourceDelta(IResourceDelta delta) {
+		convertToRustFileLocation(delta.getResource()).ifPresent(location -> {
+			switch(delta.getKind()) {
+			case IResourceDelta.ADDED:
+			case IResourceDelta.CHANGED:
+				enqueueFileTouchedTask(location);
+				break;
+			case IResourceDelta.REMOVED:
+				enqueueFileRemovedTask(location);
+				break;
+			}
+		});
+		return true;
+	}
+	
+	private static Optional<Location> convertToRustFileLocation(IResource resource) {
+		return Optional.of(resource)
+			.filter(res -> res instanceof IFile)
+			.filter(RustIndexManager::isValidRustPath)
+			.map(ResourceUtils::getResourceLocation);
+	}
+	
+	private static boolean isValidRustPath(IResource resource) {
+		return resource.getFullPath().toString().endsWith(".rs");
+	}
+	
+	private void enqueueFileRemovedTask(Location location) {
+		StructureInfo structureInfo = getOrCreateStructureInfo(location);
+		RustStructureUpdateTask indexUpdateTask = new RustStructureFileRemovedTask(structureInfo, location);
+		
+		structureInfo.setUpdateTask(indexUpdateTask);
+		executor.submitTask(indexUpdateTask);
+	}
+	
+	private void enqueueFileTouchedTask(Location location) {
+		StructureInfo structureInfo = getOrCreateStructureInfo(location);
+		
+		SourceProvider sourceProvider = () -> FileUtil.readFileContents(location, StringUtil.UTF8);
+		RustStructureUpdateTask indexUpdateTask =
+			new RustStructureSourceTouchedTask(structureInfo, location, sourceProvider);
+		
+		structureInfo.setUpdateTask(indexUpdateTask);
+		executor.submitTask(indexUpdateTask);
+	}
+	
+	private StructureInfo getOrCreateStructureInfo(Location location) {
+		StructureInfo structureInfo = startedIndexUpdates.get(location);
+		if(structureInfo == null) {
+			structureInfo = new StructureInfo();
+			startedIndexUpdates.put(location, structureInfo);
+		}
+		return structureInfo;
+	}
+	
+	private class StructureInfo extends StructureResult<StructureInfo> {
+		@Override
+		protected void doHandleDataChanged() {
+			getStructure().ifPresent(
+				structure -> {
+					sourceStructure.updateIndex(structure);
+					structure.getLocation().ifPresent(startedIndexUpdates::remove);
+				});
+		}
+	}
+	
+	@Override
+	public List<StructureElement> getGlobalSourceStructure() {
+		return sourceStructure.getGlobalSourceStructure();
+	}
+}

--- a/plugin_ide.core/src/com/github/rustdt/ide/core/engine/RustSourceModelManager.java
+++ b/plugin_ide.core/src/com/github/rustdt/ide/core/engine/RustSourceModelManager.java
@@ -10,26 +10,12 @@
  *******************************************************************************/
 package com.github.rustdt.ide.core.engine;
 
-import java.nio.file.Path;
-
-import org.eclipse.core.resources.IProject;
-
-import com.github.rustdt.ide.core.operations.RustSDKPreferences;
-import com.github.rustdt.tooling.ops.RustParseDescribeParser;
+import com.github.rustdt.ide.core.engine.RustStructureUpdateTask.RustStructureSourceTouchedTask;
 
 import melnorme.lang.ide.core.LangCore;
 import melnorme.lang.ide.core.engine.SourceModelManager;
+import melnorme.lang.ide.core.engine.StructureUpdateTask;
 import melnorme.lang.ide.core.operations.ToolManager;
-import melnorme.lang.ide.core.utils.ResourceUtils;
-import melnorme.lang.tooling.structure.SourceFileStructure;
-import melnorme.lang.tooling.structure.StructureElement;
-import melnorme.utilbox.collections.Indexable;
-import melnorme.utilbox.concurrency.OperationCancellation;
-import melnorme.utilbox.core.CommonException;
-import melnorme.utilbox.core.DevelopmentCodeMarkers;
-import melnorme.utilbox.misc.Location;
-import melnorme.utilbox.misc.StringUtil;
-import melnorme.utilbox.process.ExternalProcessHelper.ExternalProcessResult;
 
 public class RustSourceModelManager extends SourceModelManager {
 	
@@ -40,66 +26,6 @@ public class RustSourceModelManager extends SourceModelManager {
 	
 	@Override
 	protected StructureUpdateTask createUpdateTask(StructureInfo structureInfo, String source) {
-		return new RustStructureUpdateTask(structureInfo, source);
+		return new RustStructureSourceTouchedTask(structureInfo, structureInfo.getLocation(), () -> source);
 	}
-	
-	public class RustStructureUpdateTask extends StructureUpdateTask {
-		
-		protected final String source;
-		
-		public RustStructureUpdateTask(StructureInfo structureInfo, String source) {
-			super(structureInfo);
-			this.source = source;
-		}
-		
-		@Override
-		protected SourceFileStructure doCreateNewData() throws CommonException, OperationCancellation {
-			
-			Location fileLocation = structureInfo.getLocation();
-			
-			String describeOutput = getDescribeOutput(source, fileLocation);
-			if(describeOutput == null) {
-				return null;
-			}
-			
-			try {
-				RustParseDescribeParser parseDescribe = new RustParseDescribeParser(fileLocation, source);
-				SourceFileStructure newStructure = parseDescribe.parse(describeOutput);
-				if(newStructure.getParserProblems().size() > 0 && newStructure.getChildren().isEmpty()) {
-					
-					SourceFileStructure previousStructure = structureInfo.getStoredData().getOrNull();
-					if(previousStructure != null) {
-						// Use elements from previous structure:
-						Indexable<StructureElement> previousElements = 
-								StructureElement.cloneSubTree(previousStructure.getChildren());
-						
-						newStructure = new SourceFileStructure(fileLocation, previousElements, 
-							newStructure.getParserProblems());
-					}
-				}
-				return newStructure;
-			} catch(CommonException ce) {
-				throw new CommonException("Error reading parse-describe output:", ce.toStatusException());
-				//toolManager.logAndNotifyError("Error reading parse-describe output:", ce.toStatusException());
-			}
-			
-		}
-		
-		protected String getDescribeOutput(String source, Location fileLocation) 
-				throws OperationCancellation, CommonException {
-			if(DevelopmentCodeMarkers.TESTS_MODE) {
-				return null;
-			}
-			
-			IProject project = fileLocation == null ? null : ResourceUtils.getProjectFromMemberLocation(fileLocation);
-				Path path = RustSDKPreferences.RAINICORN_PATH2.getDerivedValue(project);
-				
-				ProcessBuilder pb = toolManager.createToolProcessBuilder(project, path);
-				
-				ExternalProcessResult describeResult = toolManager.runEngineTool(pb, source, cm);
-				return describeResult.getStdOutBytes().toString(StringUtil.UTF8);
-				
-		}
-	}
-	
 }

--- a/plugin_ide.core/src/com/github/rustdt/ide/core/engine/RustStructureUpdateTask.java
+++ b/plugin_ide.core/src/com/github/rustdt/ide/core/engine/RustStructureUpdateTask.java
@@ -1,0 +1,59 @@
+package com.github.rustdt.ide.core.engine;
+
+import com.github.rustdt.ide.core.operations.RustParseDescribeLauncher;
+import com.github.rustdt.tooling.ops.RustParseDescribeParser;
+
+import melnorme.lang.ide.core.LangCore;
+import melnorme.lang.ide.core.engine.StructureResult;
+import melnorme.lang.ide.core.engine.StructureUpdateTask;
+import melnorme.lang.tooling.structure.SourceFileStructure;
+import melnorme.utilbox.collections.Indexable;
+import melnorme.utilbox.concurrency.OperationCancellation;
+import melnorme.utilbox.core.CommonException;
+import melnorme.utilbox.misc.Location;
+
+abstract class RustStructureUpdateTask extends StructureUpdateTask {
+	RustStructureUpdateTask(StructureResult<?> derivedData, Location location) {
+		super(derivedData, location);
+	}
+	
+	@Override
+	protected void handleRuntimeException(RuntimeException e) {
+		LangCore.logInternalError(e);
+	}
+	
+	interface SourceProvider {
+		String provideSource() throws CommonException;
+	}
+	
+	static class RustStructureSourceTouchedTask extends RustStructureUpdateTask {
+		private final SourceProvider sourceProvider;
+		
+		RustStructureSourceTouchedTask(StructureResult<?> structureResult, Location location, SourceProvider sourceProvider) {
+			super(structureResult, location);
+			this.sourceProvider = sourceProvider;
+		}
+		
+		@Override
+		protected SourceFileStructure doCreateNewData() throws OperationCancellation, CommonException {
+			String source = sourceProvider.provideSource();
+			RustParseDescribeLauncher parseDescribeLauncher = new RustParseDescribeLauncher(
+				LangCore.getToolManager(), this::isCancelled);
+			String parseDescribeStdout = parseDescribeLauncher.getDescribeOutput(source, location);
+			
+			RustParseDescribeParser parseDescribeParser = new RustParseDescribeParser(location, source);
+			return parseDescribeParser.parse(parseDescribeStdout);
+		}
+	}
+	
+	static class RustStructureFileRemovedTask extends RustStructureUpdateTask {
+		RustStructureFileRemovedTask(StructureResult<?> structureResult, Location location) {
+			super(structureResult, location);
+		}
+		
+		@Override
+		protected SourceFileStructure doCreateNewData() {
+			return new SourceFileStructure(location, Indexable.EMPTY_INDEXABLE, Indexable.EMPTY_INDEXABLE);
+		}
+	}
+}

--- a/plugin_ide.core/src/com/github/rustdt/ide/core/operations/RustParseDescribeLauncher.java
+++ b/plugin_ide.core/src/com/github/rustdt/ide/core/operations/RustParseDescribeLauncher.java
@@ -1,0 +1,40 @@
+package com.github.rustdt.ide.core.operations;
+
+import java.nio.file.Path;
+
+import org.eclipse.core.resources.IProject;
+
+import melnorme.lang.ide.core.operations.ToolManager;
+import melnorme.lang.ide.core.utils.ResourceUtils;
+import melnorme.utilbox.concurrency.ICancelMonitor;
+import melnorme.utilbox.concurrency.OperationCancellation;
+import melnorme.utilbox.core.CommonException;
+import melnorme.utilbox.core.DevelopmentCodeMarkers;
+import melnorme.utilbox.misc.Location;
+import melnorme.utilbox.misc.StringUtil;
+import melnorme.utilbox.process.ExternalProcessHelper.ExternalProcessResult;
+
+public class RustParseDescribeLauncher {
+	protected final ToolManager toolManager;
+	protected final ICancelMonitor cancelMonitor;
+	
+	public RustParseDescribeLauncher(ToolManager toolManager, ICancelMonitor cancelMonitor) {
+		this.toolManager = toolManager;
+		this.cancelMonitor = cancelMonitor;
+	}
+	
+	public String getDescribeOutput(String source, Location fileLocation)
+			throws OperationCancellation, CommonException {
+		if(DevelopmentCodeMarkers.TESTS_MODE) {
+			return "RUST_PARSE_DESCRIBE 1.0 { MESSAGES {} }";
+		}
+		
+		IProject project = fileLocation == null ? null : ResourceUtils.getProjectFromMemberLocation(fileLocation);
+		Path path = RustSDKPreferences.RAINICORN_PATH2.getDerivedValue(project);
+		
+		ProcessBuilder pb = toolManager.createToolProcessBuilder(project, path);
+		
+		ExternalProcessResult describeResult = toolManager.runEngineTool(pb, source, cancelMonitor);
+		return describeResult.getStdOutBytes().toString(StringUtil.UTF8);
+	}
+}

--- a/plugin_ide.core/src/melnorme/lang/ide/core/LangCore_Actual.java
+++ b/plugin_ide.core/src/melnorme/lang/ide/core/LangCore_Actual.java
@@ -11,6 +11,7 @@
 package melnorme.lang.ide.core;
 
 import com.github.rustdt.ide.core.cargomodel.RustBundleModelManager;
+import com.github.rustdt.ide.core.engine.RustIndexManager;
 import com.github.rustdt.ide.core.engine.RustLanguageServerHandler;
 import com.github.rustdt.ide.core.engine.RustSourceModelManager;
 import com.github.rustdt.ide.core.operations.RustBuildManager;
@@ -23,7 +24,7 @@ import melnorme.utilbox.misc.ILogHandler;
 public class LangCore_Actual extends AbstractLangCore {
 	
 	public static final String PLUGIN_ID = "com.github.rustdt.ide.core";
-	public static final String NATURE_ID = PLUGIN_ID +".nature";
+	public static final String NATURE_ID = PLUGIN_ID + ".nature";
 	
 	public static final String BUILDER_ID = PLUGIN_ID + ".Builder";
 	public static final String BUILD_PROBLEM_ID = PLUGIN_ID + ".build_problem";
@@ -66,6 +67,9 @@ public class LangCore_Actual extends AbstractLangCore {
 		return new RustSourceModelManager();
 	}
 	
+	public static RustIndexManager createIndexManager() {
+		return new RustIndexManager();
+	}
 	
 	public static RustBundleModelManager createBundleModelManager() {
 		return new RustBundleModelManager();

--- a/plugin_ide.ui/plugin.properties
+++ b/plugin_ide.ui/plugin.properties
@@ -43,6 +43,9 @@ GoToMatchingBracketAction.description=Moves the cursor to the matching bracket
 QuickOutlineAction.name=Quick Outline
 QuickOutlineAction.description=Quick Outline
 
+OpenTypeAction.name=Open Type
+OpenTypeAction.description=Open Type
+
 FormatAction.name=Format
 FormatAction.description=Format the current file.
 

--- a/plugin_ide.ui/plugin.xml
+++ b/plugin_ide.ui/plugin.xml
@@ -153,6 +153,13 @@
 		
 		<command 
 			categoryId="com.github.rustdt.ide.ui.commands.Category"
+			id="com.github.rustdt.ide.ui.commands.OpenType"
+			name="%OpenTypeAction.name"
+			description="%OpenTypeAction.description"
+		/>
+		
+		<command 
+			categoryId="com.github.rustdt.ide.ui.commands.Category"
 			id="com.github.rustdt.ide.ui.commands.Format"
 			name="%FormatAction.name"
 			description="%FormatAction.description"
@@ -189,6 +196,12 @@
 			contextId="com.github.rustdt.ide.ui.Contexts.Editor"
 			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
 			sequence="M1+O">
+		</key>
+		<key
+			commandId="com.github.rustdt.ide.ui.commands.OpenType"
+			contextId="com.github.rustdt.ide.ui.Contexts.Editor"
+			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+			sequence="M1+M2+T">
 		</key>
 		<key
 			commandId="org.eclipse.ui.edit.text.shiftLeft"

--- a/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/dialogs/PickTypeDialog.java
+++ b/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/dialogs/PickTypeDialog.java
@@ -1,0 +1,30 @@
+package melnorme.lang.ide.ui.dialogs;
+
+
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.swt.widgets.Shell;
+
+import melnorme.lang.ide.ui.LangUIPlugin_Actual;
+import melnorme.lang.ide.ui.views.EnhancedSelectionDialog;
+import melnorme.lang.ide.ui.views.StructureElementLabelProvider.AdditionalInfo;
+import melnorme.lang.tooling.structure.StructureElement;
+
+public class PickTypeDialog {
+	public static Optional<StructureElement> show(Shell parent, List<StructureElement> elements,
+		boolean matchEmptyStrings) {
+		EnhancedSelectionDialog dialog =
+			new EnhancedSelectionDialog(parent,
+				LangUIPlugin_Actual.getStructureElementLabelProvider(AdditionalInfo.LOCATION));
+		
+		dialog.setTitle("Open Type");
+		dialog.setHelpAvailable(false);
+		dialog.setMatchEmptyString(matchEmptyStrings);
+		dialog.setMessage("Enter type name prefix or pattern (*, ? or camel case):");
+		dialog.setElements(elements.toArray());
+		dialog.open();
+		
+		return Optional.ofNullable((StructureElement) dialog.getFirstResult());
+	}
+}

--- a/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/editor/AbstractLangEditor.java
+++ b/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/editor/AbstractLangEditor.java
@@ -194,6 +194,7 @@ public abstract class AbstractLangEditor extends TextEditorExt {
 	public LangSourceViewer getSourceViewer_() {
 		return (LangSourceViewer) getSourceViewer();
 	}
+	
 	public ISourceViewerExt getSourceViewer_asExt() {
 		return (ISourceViewerExt) getSourceViewer();
 	}

--- a/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/editor/LangEditorActionContributor.java
+++ b/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/editor/LangEditorActionContributor.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package melnorme.lang.ide.ui.editor;
 
-
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.Separator;
@@ -30,6 +29,7 @@ import melnorme.lang.ide.ui.editor.EditorUtils.OpenNewEditorMode;
 import melnorme.lang.ide.ui.editor.actions.AbstractEditorHandler;
 import melnorme.lang.ide.ui.editor.actions.GoToMatchingBracketHandler;
 import melnorme.lang.ide.ui.editor.actions.OpenQuickOutlineHandler;
+import melnorme.lang.ide.ui.editor.actions.OpenTypeHandler;
 import melnorme.lang.ide.ui.editor.actions.ToggleCommentHandler;
 import melnorme.lang.ide.ui.utils.operations.AbstractEditorOperation2;
 import melnorme.lang.ide.ui.utils.operations.BasicUIOperation;
@@ -78,6 +78,7 @@ public abstract class LangEditorActionContributor extends LangEditorActionContri
 		activateHandler(EditorCommandIds.ToggleComment, getHandler_ToggleComment());
 		
 		activateHandler(EditorCommandIds.QuickOutline, getHandler_QuickOutline());
+		activateHandler(EditorCommandIds.OpenType, getHandler_OpenType());
 		
 		activateHandler(EditorCommandIds.Format, getHandler_Format());
 		
@@ -119,6 +120,10 @@ public abstract class LangEditorActionContributor extends LangEditorActionContri
 		return new OpenQuickOutlineHandler(getPage());
 	}
 	
+	protected AbstractHandler getHandler_OpenType() {
+		return new OpenTypeHandler(getPage());
+	}
+	
 	public AbstractEditorHandler getHandler_Format() {
 		return getEditorHandler(getOpCreator_Format());
 	}
@@ -149,6 +154,7 @@ public abstract class LangEditorActionContributor extends LangEditorActionContri
 	protected void prepareNavigateMenu(IMenuManager menu) {
 		IMenuManager navigateMenu = menu.findMenuUsingPath(IWorkbenchActionConstants.M_NAVIGATE);
 		if(navigateMenu != null) {
+			navigateMenu.appendToGroup(IWorkbenchActionConstants.SHOW_EXT, pushItem(EditorCommandIds.OpenType));
 			navigateMenu.appendToGroup(IWorkbenchActionConstants.SHOW_EXT, pushItem(EditorCommandIds.QuickOutline));
 		}
 		
@@ -161,7 +167,7 @@ public abstract class LangEditorActionContributor extends LangEditorActionContri
 	}
 	
 	protected void prepareEditMenu(IMenuManager menu) {
-		IMenuManager editMenu= menu.findMenuUsingPath(IWorkbenchActionConstants.M_EDIT);
+		IMenuManager editMenu = menu.findMenuUsingPath(IWorkbenchActionConstants.M_EDIT);
 		if(editMenu != null) {
 			editMenu.appendToGroup(ITextEditorActionConstants.GROUP_ASSIST, pushItem(
 				ITextEditorActionDefinitionIds.CONTENT_ASSIST_PROPOSALS, 

--- a/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/editor/actions/OpenTypeHandler.java
+++ b/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/editor/actions/OpenTypeHandler.java
@@ -10,17 +10,19 @@
  *******************************************************************************/
 package melnorme.lang.ide.ui.editor.actions;
 
+import java.util.Optional;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 import melnorme.lang.ide.core.LangCore;
-import melnorme.lang.ide.ui.LangUIPlugin_Actual;
+import melnorme.lang.ide.ui.dialogs.PickTypeDialog;
 import melnorme.lang.ide.ui.editor.AbstractLangEditor;
 import melnorme.lang.ide.ui.editor.LangEditorMessages;
 import melnorme.lang.ide.ui.editor.structure.EditorStructureUtil;
 import melnorme.lang.ide.ui.utils.operations.BasicEditorOperation;
-import melnorme.lang.ide.ui.views.EnhancedSelectionDialog;
+import melnorme.lang.tooling.structure.StructureElement;
 import melnorme.utilbox.core.CommonException;
 
 public class OpenTypeHandler extends AbstractEditorHandler {
@@ -33,17 +35,10 @@ public class OpenTypeHandler extends AbstractEditorHandler {
 		return new BasicEditorOperation(LangEditorMessages.QuickOutline_title, editor) {
 			@Override
 			protected void doRunWithEditor(AbstractLangEditor editor) throws CommonException {
-				EnhancedSelectionDialog dialog = new EnhancedSelectionDialog(
-					getShell(), LangUIPlugin_Actual.getStructureElementLabelProvider());
-				
-				dialog.setTitle("Open Type");
-				dialog.setHelpAvailable(false);
-				dialog.setMatchEmptyString(false);
-				dialog.setMessage("Enter type name prefix or pattern (*, ? or camel case):");
-				dialog.setElements(LangCore.getIndexManager().getGlobalSourceStructure().toArray());
-				dialog.open();
+				Optional<StructureElement> pickedType =
+					PickTypeDialog.show(getShell(), LangCore.getIndexManager().getGlobalSourceStructure(), false);
 				try {
-					EditorStructureUtil.openInEditorAndReveal(dialog.getFirstResult());
+					EditorStructureUtil.openInEditorAndReveal(pickedType.orElse(null));
 				} catch(CoreException e) {
 					throw new CommonException("Could not open global source structure", e);
 				}

--- a/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/editor/actions/OpenTypeHandler.java
+++ b/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/editor/actions/OpenTypeHandler.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bruno Medeiros and other Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Bruno Medeiros - initial API and implementation
+ *******************************************************************************/
+package melnorme.lang.ide.ui.editor.actions;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+import melnorme.lang.ide.core.LangCore;
+import melnorme.lang.ide.ui.LangUIPlugin_Actual;
+import melnorme.lang.ide.ui.editor.AbstractLangEditor;
+import melnorme.lang.ide.ui.editor.LangEditorMessages;
+import melnorme.lang.ide.ui.editor.structure.EditorStructureUtil;
+import melnorme.lang.ide.ui.utils.operations.BasicEditorOperation;
+import melnorme.lang.ide.ui.views.EnhancedSelectionDialog;
+import melnorme.utilbox.core.CommonException;
+
+public class OpenTypeHandler extends AbstractEditorHandler {
+	public OpenTypeHandler(IWorkbenchPage page) {
+		super(page);
+	}
+	
+	@Override
+	protected BasicEditorOperation createOperation(ITextEditor editor) {
+		return new BasicEditorOperation(LangEditorMessages.QuickOutline_title, editor) {
+			@Override
+			protected void doRunWithEditor(AbstractLangEditor editor) throws CommonException {
+				EnhancedSelectionDialog dialog = new EnhancedSelectionDialog(
+					getShell(), LangUIPlugin_Actual.getStructureElementLabelProvider());
+				
+				dialog.setTitle("Open Type");
+				dialog.setHelpAvailable(false);
+				dialog.setMatchEmptyString(false);
+				dialog.setMessage("Enter type name prefix or pattern (*, ? or camel case):");
+				dialog.setElements(LangCore.getIndexManager().getGlobalSourceStructure().toArray());
+				dialog.open();
+				try {
+					EditorStructureUtil.openInEditorAndReveal(dialog.getFirstResult());
+				} catch(CoreException e) {
+					throw new CommonException("Could not open global source structure", e);
+				}
+			}
+		};
+	}
+	
+}

--- a/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/editor/structure/EditorStructureUtil.java
+++ b/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/editor/structure/EditorStructureUtil.java
@@ -11,28 +11,29 @@
 package melnorme.lang.ide.ui.editor.structure;
 
 import static melnorme.lang.ide.ui.EditorSettings_Actual.EDITOR_ID;
-import melnorme.lang.ide.ui.editor.EditorUtils;
-import melnorme.lang.tooling.structure.ISourceFileStructure;
-import melnorme.lang.tooling.structure.StructureElement;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.texteditor.ITextEditor;
 
-public class EditorStructureUtil {
+import melnorme.lang.ide.ui.editor.EditorUtils;
+import melnorme.lang.tooling.structure.ISourceFileStructure;
+import melnorme.lang.tooling.structure.StructureElement;
 
+public class EditorStructureUtil {
+	
 	public static void openInEditorAndReveal(Object selectedElement) throws CoreException {
 		
 		if(selectedElement instanceof StructureElement) {
 			StructureElement structureElement = (StructureElement) selectedElement;
 			
 			ISourceFileStructure fileStructure = structureElement.getContainingFileStructure();
-			if(fileStructure == null || fileStructure.getLocation() == null) {
+			if(fileStructure == null || !fileStructure.getLocation().isPresent()) {
 				return;
 			}
 			
-			IEditorInput newInput = EditorUtils.getBestEditorInputForLoc(fileStructure.getLocation());
+			IEditorInput newInput = EditorUtils.getBestEditorInputForLoc(fileStructure.getLocation().get());
 			
 			IEditorPart part = EditorUtils.openEditor(newInput, EDITOR_ID, true);
 			revealInEditor(part, structureElement);

--- a/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/text/completion/LangCompletionProposalComputer.java
+++ b/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/text/completion/LangCompletionProposalComputer.java
@@ -27,6 +27,7 @@ import melnorme.lang.ide.ui.LangUIPlugin_Actual;
 import melnorme.lang.ide.ui.editor.EditorUtils;
 import melnorme.lang.ide.ui.views.AbstractLangImageProvider;
 import melnorme.lang.ide.ui.views.StructureElementLabelProvider;
+import melnorme.lang.ide.ui.views.StructureElementLabelProvider.AdditionalInfo;
 import melnorme.lang.tooling.ToolCompletionProposal;
 import melnorme.lang.tooling.toolchain.ops.OperationSoftFailure;
 import melnorme.lang.tooling.toolchain.ops.SourceOpContext;
@@ -101,7 +102,8 @@ public abstract class LangCompletionProposalComputer extends AbstractCompletionP
 	public ImageDescriptor createImageDescriptor(ToolCompletionProposal proposal) {
 		ImageDescriptor baseImage = getBaseImageDescriptor(proposal);
 		
-		StructureElementLabelProvider labelDecorator = LangUIPlugin_Actual.getStructureElementLabelProvider();
+		StructureElementLabelProvider labelDecorator =
+			LangUIPlugin_Actual.getStructureElementLabelProvider(AdditionalInfo.SIGNATURE);
 		return labelDecorator.getElementImageDescriptor(baseImage, proposal.getAttributes());
 	}
 	

--- a/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/utils/operations/AbstractEditorOperation2.java
+++ b/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/utils/operations/AbstractEditorOperation2.java
@@ -44,6 +44,7 @@ public abstract class AbstractEditorOperation2<RESULT> extends CalculateValueUIO
 	protected final EditorSourceBuffer sourceBuffer;
 	protected final IDocument doc;
 	protected final IProject project;
+	protected final SourceRange range;
 	private final SourceOpContext sourceOpContext;
 	
 	
@@ -53,6 +54,7 @@ public abstract class AbstractEditorOperation2<RESULT> extends CalculateValueUIO
 	
 	public AbstractEditorOperation2(String operationName, ITextEditor editor, SourceRange range) {
 		super(operationName);
+		this.range = range;
 		this.editor = assertNotNull(editor);
 		this.window = editor.getSite().getWorkbenchWindow();
 		

--- a/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/views/EnhancedSelectionDialog.java
+++ b/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/views/EnhancedSelectionDialog.java
@@ -1,0 +1,40 @@
+package melnorme.lang.ide.ui.views;
+
+import org.eclipse.jface.viewers.ILabelProvider;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.dialogs.ElementListSelectionDialog;
+import org.eclipse.ui.dialogs.FilteredList;
+import org.eclipse.ui.dialogs.FilteredList.FilterMatcher;
+import org.eclipse.ui.dialogs.SearchPattern;
+
+/**
+ * Enhanced search dialog with support for wildcards, camel case searches and the like
+ */
+public final class EnhancedSelectionDialog extends ElementListSelectionDialog {
+	SearchPattern searchPatternWithCamelCase = new SearchPattern();
+	private final ILabelProvider renderer;
+	
+	public EnhancedSelectionDialog(Shell parent, ILabelProvider renderer) {
+		super(parent, renderer);
+		this.renderer = renderer;
+	}
+	
+	@Override
+	protected FilteredList createFilteredList(Composite parent) {
+		FilteredList filteredList = super.createFilteredList(parent);
+		filteredList.setFilterMatcher(new FilterMatcher() {
+			@Override
+			public void setFilter(String pattern, boolean ignoreCase, boolean ignoreWildCards) {
+				searchPatternWithCamelCase.setPattern(pattern);
+			}
+			
+			@Override
+			public boolean match(Object element) {
+				String elementText = renderer.getText(element);
+				return searchPatternWithCamelCase.matches(elementText);
+			}
+		});
+		return filteredList;
+	}
+}

--- a/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/views/EnhancedSelectionDialog.java
+++ b/plugin_ide.ui/src-lang/melnorme/lang/ide/ui/views/EnhancedSelectionDialog.java
@@ -8,16 +8,16 @@ import org.eclipse.ui.dialogs.FilteredList;
 import org.eclipse.ui.dialogs.FilteredList.FilterMatcher;
 import org.eclipse.ui.dialogs.SearchPattern;
 
+import melnorme.lang.tooling.structure.StructureElement;
+
 /**
  * Enhanced search dialog with support for wildcards, camel case searches and the like
  */
 public final class EnhancedSelectionDialog extends ElementListSelectionDialog {
 	SearchPattern searchPatternWithCamelCase = new SearchPattern();
-	private final ILabelProvider renderer;
 	
 	public EnhancedSelectionDialog(Shell parent, ILabelProvider renderer) {
 		super(parent, renderer);
-		this.renderer = renderer;
 	}
 	
 	@Override
@@ -31,7 +31,7 @@ public final class EnhancedSelectionDialog extends ElementListSelectionDialog {
 			
 			@Override
 			public boolean match(Object element) {
-				String elementText = renderer.getText(element);
+				String elementText = ((StructureElement) element).getName();
 				return searchPatternWithCamelCase.matches(elementText);
 			}
 		});

--- a/plugin_ide.ui/src/com/github/rustdt/ide/ui/actions/RustOpenDefinitionOperation.java
+++ b/plugin_ide.ui/src/com/github/rustdt/ide/ui/actions/RustOpenDefinitionOperation.java
@@ -10,17 +10,30 @@
  *******************************************************************************/
 package com.github.rustdt.ide.ui.actions;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 import com.github.rustdt.ide.core.operations.RustSDKPreferences;
+import com.github.rustdt.tooling.ops.RacerCompletionResult;
 import com.github.rustdt.tooling.ops.RacerFindDefinitionOperation;
 
+import melnorme.lang.ide.core.LangCore;
 import melnorme.lang.ide.core.operations.ToolManager.ToolManagerEngineToolRunner;
+import melnorme.lang.ide.core.text.JavaWordFinder;
 import melnorme.lang.ide.ui.LangUIMessages;
+import melnorme.lang.ide.ui.dialogs.PickTypeDialog;
 import melnorme.lang.ide.ui.editor.EditorUtils.OpenNewEditorMode;
 import melnorme.lang.ide.ui.editor.actions.AbstractOpenElementOperation;
 import melnorme.lang.tooling.ast.SourceRange;
 import melnorme.lang.tooling.common.ops.IOperationMonitor;
+import melnorme.lang.tooling.structure.StructureElement;
 import melnorme.lang.tooling.toolchain.ops.OperationSoftFailure;
 import melnorme.lang.tooling.toolchain.ops.SourceLocation;
 import melnorme.utilbox.concurrency.OperationCancellation;
@@ -34,17 +47,60 @@ public class RustOpenDefinitionOperation extends AbstractOpenElementOperation {
 	
 	@Override
 	protected SourceLocation doBackgroundToolResultComputation(IOperationMonitor om)
-			throws CommonException, OperationCancellation, OperationSoftFailure {
-		
-		ToolManagerEngineToolRunner toolRunner = getToolManager().new ToolManagerEngineToolRunner();
-		
-		RacerFindDefinitionOperation op = new RacerFindDefinitionOperation(toolRunner, 
-			RustSDKPreferences.RACER_PATH.getValidatableValue(project) , 
-			RustSDKPreferences.SDK_SRC_PATH3.getValidatableValue(project),
-			getSourceOpContext()
-		);
-		
-		return op.executeToolOperation(om);
+		throws CommonException, OperationCancellation, OperationSoftFailure {
+		try {
+			try {
+				return getLocationProvidedByRacer(om);
+			} catch(CommonException e) {
+				return getLocationProvidedByIndex(e);
+			}
+		} catch(BadLocationException e) {
+			throw new CommonException(e.getMessage(), e);
+		}
 	}
 	
+	private SourceLocation getLocationProvidedByRacer(IOperationMonitor om)
+		throws CommonException, OperationCancellation, OperationSoftFailure, BadLocationException {
+		ToolManagerEngineToolRunner toolRunner = getToolManager().new ToolManagerEngineToolRunner();
+		RacerFindDefinitionOperation op =
+			new RacerFindDefinitionOperation(toolRunner, RustSDKPreferences.RACER_PATH.getValidatableValue(project),
+				RustSDKPreferences.SDK_SRC_PATH3.getValidatableValue(project), getSourceOpContext());
+		RacerCompletionResult racerCompletionResult = op.executeToolOperation(om);
+		return SourceLocation.forOneBasedLineAndColNumber(racerCompletionResult.location,
+			racerCompletionResult.oneBasedLineNumber, racerCompletionResult.zeroBasedColumnNumber);
+	}
+	
+	private SourceLocation getLocationProvidedByIndex(CommonException initialException)
+		throws BadLocationException, CommonException {
+		String searchTerm = getSearchTerm();
+		List<StructureElement> candidates = LangCore.getIndexManager().getGlobalSourceStructure().stream()
+			.filter(structureElement -> structureElement.getName().equals(searchTerm))
+			.collect(Collectors.toList());
+		
+		StructureElement selectedCandidate;
+		if(candidates.isEmpty()) {
+			throw initialException;
+		} else if(candidates.size() == 1) {
+			selectedCandidate = candidates.get(0);
+		} else {
+			Shell shell = editor.getSite().getWorkbenchWindow().getShell();
+			AtomicReference<StructureElement> reference = new AtomicReference<>();
+			Display.getDefault().syncExec(
+				() -> reference.set(PickTypeDialog.show(shell, candidates, true).orElse(null)));
+			selectedCandidate = reference.get();
+		}
+		
+		return selectedCandidate != null ? SourceLocation.forSourceRange(selectedCandidate.getLocation().get(),
+			selectedCandidate.getNameSourceRange2()) : null;
+	}
+
+	private String getSearchTerm() throws BadLocationException {
+		boolean somethingWasSelected = range.length != 0;
+		if(somethingWasSelected) {
+			return doc.get(range.offset, range.length);
+		} else {
+			IRegion wordRegionAroundCursor = JavaWordFinder.findWord(doc, range.offset);
+			return doc.get(wordRegionAroundCursor.getOffset(), wordRegionAroundCursor.getLength());
+		}
+	}
 }

--- a/plugin_ide.ui/src/melnorme/lang/ide/ui/EditorSettings_Actual.java
+++ b/plugin_ide.ui/src/melnorme/lang/ide/ui/EditorSettings_Actual.java
@@ -99,6 +99,7 @@ public class EditorSettings_Actual {
 		public static final String ToggleComment = LangUIPlugin.PLUGIN_ID + ".commands.ToggleComment";
 		
 		public static final String QuickOutline = LangUIPlugin.PLUGIN_ID + ".commands.QuickOutline";
+		public static final String OpenType = LangUIPlugin.PLUGIN_ID + ".commands.OpenType";
 		public static final String Format = LangUIPlugin.PLUGIN_ID + ".commands.Format";
 		
 	}

--- a/plugin_ide.ui/src/melnorme/lang/ide/ui/LangUIPlugin_Actual.java
+++ b/plugin_ide.ui/src/melnorme/lang/ide/ui/LangUIPlugin_Actual.java
@@ -17,6 +17,7 @@ import melnorme.lang.ide.core_text.LangDocumentPartitionerSetup;
 import melnorme.lang.ide.ui.editor.hover.ILangEditorTextHover;
 import melnorme.lang.ide.ui.editor.text.LangAutoEditsPreferencesAccess;
 import melnorme.lang.ide.ui.views.StructureElementLabelProvider;
+import melnorme.lang.ide.ui.views.StructureElementLabelProvider.AdditionalInfo;
 import melnorme.lang.tooling.structure.StructureElement;
 import melnorme.lang.tooling.structure.StructureElementKind;
 
@@ -57,8 +58,8 @@ public final class LangUIPlugin_Actual {
 		return new RustDocumentSetupParticipant();
 	}
 	
-	public static StructureElementLabelProvider getStructureElementLabelProvider() {
-		return new StructureElementLabelProvider() {
+	public static StructureElementLabelProvider getStructureElementLabelProvider(AdditionalInfo additionalInfo) {
+		return new StructureElementLabelProvider(additionalInfo) {
 			@Override
 			protected String getTypeDescriptionPrefix(StructureElement structureElement) {
 				if(structureElement.getKind() == StructureElementKind.FUNCTION) {

--- a/plugin_tooling.tests/source/src-lang/melnorme/lang/tooling/toolchain/ops/SourceLocationTest.java
+++ b/plugin_tooling.tests/source/src-lang/melnorme/lang/tooling/toolchain/ops/SourceLocationTest.java
@@ -1,0 +1,37 @@
+package melnorme.lang.tooling.toolchain.ops;
+
+import java.util.function.BiFunction;
+
+import org.junit.Test;
+
+import melnorme.lang.tooling.ast.SourceRange;
+import melnorme.utilbox.misc.Location;
+import melnorme.utilbox.tests.CommonTest;
+
+public class SourceLocationTest extends CommonTest {
+	@Test
+	public void rangeBasedSourceLocationReturnsSourceRangeWithoutInvokingTheMapper() throws Exception {
+		Location location = Location.create("/");
+		SourceRange sourceRange = SourceRange.srStartToEnd(0, 100);
+		SourceLocation sourceLocation = SourceLocation.forSourceRange(location, sourceRange);
+		
+		BiFunction<Integer, Integer, Integer> evilMapper = (a, b) -> {
+			throw new RuntimeException();
+		};
+		
+		assertEquals(sourceLocation.getSourceRange(evilMapper), sourceRange);
+		assertEquals(sourceLocation.getFileLocation(), location);
+	}
+	
+	@Test
+	public void linesAndColsBasedSourceLocationReturnsSourceRangeEvaluatedByTheMapper() throws Exception {
+		Location location = Location.create("/");
+		SourceLocation sourceLocation = SourceLocation.forOneBasedLineAndColNumber(location, 3, 5);
+		
+		BiFunction<Integer, Integer, Integer> summarizingFakeMapper = (a, b) -> a + b;
+		
+		SourceRange expectedSourceRange = new SourceRange(8, 0);
+		assertEquals(sourceLocation.getSourceRange(summarizingFakeMapper), expectedSourceRange);
+		assertEquals(sourceLocation.getFileLocation(), location);
+	}
+}

--- a/plugin_tooling.tests/source/src/melnorme/lang/tooling/structure/GlobalSourceStructureTest.java
+++ b/plugin_tooling.tests/source/src/melnorme/lang/tooling/structure/GlobalSourceStructureTest.java
@@ -1,0 +1,135 @@
+package melnorme.lang.tooling.structure;
+
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import melnorme.lang.tooling.ast.SourceRange;
+import melnorme.utilbox.collections.ArrayList2;
+import melnorme.utilbox.collections.Indexable;
+import melnorme.utilbox.core.CommonException;
+import melnorme.utilbox.misc.Location;
+import melnorme.utilbox.tests.CommonTest;
+
+public class GlobalSourceStructureTest extends CommonTest {
+	private final GlobalSourceStructure sourceStructure = new GlobalSourceStructure();
+	
+	@Test
+	public void initialSourceStructureIsEmpty() throws Exception {
+		assertIndexContainsNames("");
+	}
+	
+	@Test
+	public void emptyListsAreNotAdded() throws Exception {
+		sourceStructure.updateIndex(structure(Location.create("/test/path"), ArrayList2.create()));
+		assertIndexContainsNames("");
+	}
+	
+	@Test
+	public void nonEmptyListsAreAdded() throws Exception {
+		sourceStructure.updateIndex(structure(Location.create("/test/path"), ArrayList2.create(element("a"))));
+		assertIndexContainsNames("a");
+	}
+	
+	@Test
+	public void emptyStructuresRemoveAlreadyAddedStructures() throws Exception {
+		sourceStructure.updateIndex(structure(Location.create("/test/path"), ArrayList2.create(element("a"))));
+		sourceStructure.updateIndex(structure(Location.create("/test/path"), ArrayList2.create()));
+		assertIndexContainsNames("");
+	}
+	
+	@Test
+	public void nonEmptyStructuresReplaceAlreadyAddedStructures() throws Exception {
+		sourceStructure.updateIndex(structure(Location.create("/test/path"), ArrayList2.create(element("a"))));
+		sourceStructure.updateIndex(structure(Location.create("/test/path"), ArrayList2.create(element("b"))));
+		assertIndexContainsNames("b");
+	}
+	
+	@Test
+	public void emptyStructuresDoNotRemoveStructuresFromDifferentPath() throws Exception {
+		sourceStructure.updateIndex(structure(Location.create("/test/a"), ArrayList2.create(element("a"))));
+		sourceStructure.updateIndex(structure(Location.create("/test/b"), ArrayList2.create()));
+		assertIndexContainsNames("a");
+	}
+	
+	@Test
+	public void nonEmptyStructuresDoNotReplaceStructuresFromDifferentPath() throws Exception {
+		sourceStructure.updateIndex(structure(Location.create("/test/a"), ArrayList2.create(element("a"))));
+		sourceStructure.updateIndex(structure(Location.create("/test/b"), ArrayList2.create(element("b"))));
+		assertIndexContainsNames("ab");
+		sourceStructure.updateIndex(structure(Location.create("/test/c"), ArrayList2.create(element("c"))));
+		assertIndexContainsNames("abc");
+		sourceStructure.updateIndex(structure(Location.create("/test/d"), ArrayList2.create(element("d"))));
+		assertIndexContainsNames("abcd");
+	}
+	
+	@Test
+	public void sourceStructureIsOrderedByPath() throws Exception {
+		sourceStructure.updateIndex(structure(Location.create("/test/a"), ArrayList2.create(element("a"))));
+		sourceStructure.updateIndex(structure(Location.create("/test/d"), ArrayList2.create(element("d"))));
+		sourceStructure.updateIndex(structure(Location.create("/test/b"), ArrayList2.create(element("b"))));
+		sourceStructure.updateIndex(structure(Location.create("/test/c"), ArrayList2.create(element("c"))));
+		sourceStructure.updateIndex(structure(Location.create("/test/f"), ArrayList2.create(element("f"))));
+		sourceStructure.updateIndex(structure(Location.create("/test/e"), ArrayList2.create(element("e"))));
+		assertIndexContainsNames("abcdef");
+	}
+	
+	@Test
+	public void sourceStructureIsOrderedByElementName() throws Exception {
+		sourceStructure.updateIndex(structure(Location.create("/test/a"),
+			ArrayList2.create(element("a"), element("d"), element("b"), element("c"), element("f"), element("e"))));
+		assertIndexContainsNames("abcdef");
+	}
+	
+	@Test
+	public void sourceStructureIsOrderedByOffset() throws Exception {
+		sourceStructure.updateIndex(
+			structure(Location.create("/test/a"), ArrayList2.create(elementWithOffset(1), elementWithOffset(4),
+				elementWithOffset(2), elementWithOffset(3), elementWithOffset(6), elementWithOffset(5))));
+		assertIndexContainsOffsets("123456");
+	}
+	
+	@Test
+	public void sourceStructureForASingleFileCannotContainTheSameNameAndRangeTwice() throws Exception {
+		sourceStructure.updateIndex(
+			structure(Location.create("/test/a"), ArrayList2.create(element("a"), element("a"), element("b"))));
+		assertIndexContainsNames("ab");
+	}
+	
+	@Test
+	public void sourceStructureIsFlattened() throws Exception {
+		sourceStructure.updateIndex(structure(Location.create("/test/a"),
+			ArrayList2.create(element("a"), element("b", element("c")), element("d"))));
+		assertIndexContainsNames("abcd");
+	}
+	
+	private static SourceFileStructure structure(Location location, ArrayList2<StructureElement> children)
+		throws CommonException {
+		return new SourceFileStructure(location, children, Indexable.EMPTY_INDEXABLE);
+	}
+	
+	private static StructureElement element(String name, StructureElement... children) {
+		return new StructureElement(name, null, new SourceRange(0, 0), StructureElementKind.UNKNOWN, null, null,
+			ArrayList2.create(children));
+	}
+	
+	private static StructureElement elementWithOffset(int offset, StructureElement... children) {
+		return new StructureElement("", null, new SourceRange(offset, 0), StructureElementKind.UNKNOWN, null, null,
+			ArrayList2.create(children));
+	}
+	
+	private void assertIndexContainsNames(String expectedStructure) {
+		String structure = sourceStructure.getGlobalSourceStructure().stream().map(StructureElement::getName)
+			.collect(Collectors.joining());
+		
+		assertEquals(structure, expectedStructure);
+	}
+	
+	private void assertIndexContainsOffsets(String expectedLocations) {
+		String structure = sourceStructure.getGlobalSourceStructure().stream()
+			.map(structureElement -> Integer.toString(structureElement.getSourceRange().getOffset()))
+			.collect(Collectors.joining());
+		
+		assertEquals(structure, expectedLocations);
+	}
+}

--- a/plugin_tooling.tests/source/src/melnorme/lang/tooling/structure/StructureElementTest.java
+++ b/plugin_tooling.tests/source/src/melnorme/lang/tooling/structure/StructureElementTest.java
@@ -1,0 +1,65 @@
+package melnorme.lang.tooling.structure;
+
+import org.junit.Test;
+
+import melnorme.lang.tooling.ast.SourceRange;
+import melnorme.utilbox.collections.ArrayList2;
+import melnorme.utilbox.tests.CommonTest;
+
+public class StructureElementTest extends CommonTest {
+	@Test
+	public void testVisitSubTree() {
+		verifySubTreeVisit(container(), "");
+		verifySubTreeVisit(container(element("a")), "a");
+		verifySubTreeVisit(container(element("a"), element("b")), "ab");
+		verifySubTreeVisit(container(element("a", element("b"))), "ab");
+		verifySubTreeVisit(container(element("a"), element("b"), element("c")), "abc");
+		verifySubTreeVisit(container(element("a", element("b")), element("c")), "abc");
+		verifySubTreeVisit(container(element("a"), element("b", element("c"))), "abc");
+		verifySubTreeVisit(container(element("a", element("b", element("c")))), "abc");
+		
+		verifySubTreeVisit(element("x"), "");
+		verifySubTreeVisit(element("x", element("a")), "a");
+		verifySubTreeVisit(element("x", element("a"), element("b")), "ab");
+		verifySubTreeVisit(element("x", element("a", element("b"))), "ab");
+		verifySubTreeVisit(element("x", element("a"), element("b"), element("c")), "abc");
+		verifySubTreeVisit(element("x", element("a", element("b")), element("c")), "abc");
+		verifySubTreeVisit(element("x", element("a"), element("b", element("c"))), "abc");
+		verifySubTreeVisit(element("x", element("a", element("b", element("c")))), "abc");
+	}
+	
+	private static void verifySubTreeVisit(AbstractStructureContainer structureToTest, String visited) {
+		StringBuilder stringBuilder = new StringBuilder();
+		structureToTest.visitSubTree(el -> stringBuilder.append(el.getName()));
+		assertEquals(stringBuilder.toString(), visited);
+	}
+	
+	@Test
+	public void testVisitTree() {
+		verifyTreeVisit(element("x"), "x");
+		verifyTreeVisit(element("x", element("a")), "xa");
+		verifyTreeVisit(element("x", element("a"), element("b")), "xab");
+		verifyTreeVisit(element("x", element("a", element("b"))), "xab");
+		verifyTreeVisit(element("x", element("a"), element("b"), element("c")), "xabc");
+		verifyTreeVisit(element("x", element("a", element("b")), element("c")), "xabc");
+		verifyTreeVisit(element("x", element("a"), element("b", element("c"))), "xabc");
+		verifyTreeVisit(element("x", element("a", element("b", element("c")))), "xabc");
+	}
+	
+	private static void verifyTreeVisit(StructureElement structureToTest, String visited) {
+		StringBuilder stringBuilder = new StringBuilder();
+		structureToTest.visitTree(el -> stringBuilder.append(el.getName()));
+		assertEquals(stringBuilder.toString(), visited);
+	}
+	
+	private static AbstractStructureContainer container(StructureElement... children) {
+		return new AbstractStructureContainer(ArrayList2.create(children)) {
+		};
+	}
+	
+	private static StructureElement element(String name, StructureElement... children) {
+		return new StructureElement(
+			name, null, new SourceRange(0, 0), StructureElementKind.UNKNOWN, null, null, ArrayList2.create(children));
+	}
+	
+}

--- a/plugin_tooling.tests/src/com/github/rustdt/tooling/ops/RacerOutputParserTest.java
+++ b/plugin_tooling.tests/src/com/github/rustdt/tooling/ops/RacerOutputParserTest.java
@@ -28,9 +28,7 @@ import melnorme.lang.tooling.ElementAttributes;
 import melnorme.lang.tooling.ToolCompletionProposal;
 import melnorme.lang.tooling.ToolingMessages;
 import melnorme.lang.tooling.ast.SourceRange;
-import melnorme.lang.tooling.common.SourceLineColumnRange;
 import melnorme.lang.tooling.toolchain.ops.OperationSoftFailure;
-import melnorme.lang.tooling.toolchain.ops.SourceLocation;
 import melnorme.utilbox.collections.ArrayList2;
 import melnorme.utilbox.core.CommonException;
 import melnorme.utilbox.misc.MiscUtil;
@@ -176,7 +174,7 @@ public class RacerOutputParserTest extends CommonToolingTest {
 		
 		testParseResolvedMatch(buildParser, 
 			"MATCH other,19,3,"+LOC_ROOT+"RustProj/src/main.rs,Function,fn other(foo: i32) {", 
-			new SourceLocation(loc(LOC_ROOT+"/RustProj/src/main.rs"), new SourceLineColumnRange(19, 4)),
+			new RacerCompletionResult(loc(LOC_ROOT + "/RustProj/src/main.rs"), 19, 4),
 			null);
 		
 		testParseResolvedMatch(buildParser, "MATCH other,as", null, "Invalid integer: `as`");
@@ -184,10 +182,12 @@ public class RacerOutputParserTest extends CommonToolingTest {
 	}
 	
 	protected void testParseResolvedMatch(RacerCompletionOutputParser buildParser, String input,
-			SourceLocation expected, String expectedException) {
+		RacerCompletionResult expected, String expectedException) {
 		try {
-			SourceLocation result = buildParser.parseResolvedMatch(input);
-			assertAreEqual(result, expected);
+			RacerCompletionResult result = buildParser.parseResolvedMatch(input);
+			assertEquals(result.location, expected.location);
+			assertEquals(result.oneBasedLineNumber, expected.oneBasedLineNumber);
+			assertEquals(result.zeroBasedColumnNumber, expected.zeroBasedColumnNumber);
 			assertTrue(expectedException == null);
 		} catch(CommonException e) {
 			assertNotNull(expectedException);

--- a/plugin_tooling/src-lang/melnorme/lang/tooling/LANG_SPECIFIC.java
+++ b/plugin_tooling/src-lang/melnorme/lang/tooling/LANG_SPECIFIC.java
@@ -7,8 +7,8 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.SOURCE)
-/** 
- * This is marker for LANG code whose contents is language specific, yet it it refered to by other LANG code.
+/**
+ * This is marker for LANG code whose contents is language specific, yet it is referred to by other LANG code.
  * Such code must not be place in the src-lang source folder
  */
 public @interface LANG_SPECIFIC {

--- a/plugin_tooling/src-lang/melnorme/lang/tooling/ast/SourceRange.java
+++ b/plugin_tooling/src-lang/melnorme/lang/tooling/ast/SourceRange.java
@@ -2,6 +2,7 @@ package melnorme.lang.tooling.ast;
 
 import static melnorme.utilbox.core.Assert.AssertNamespace.assertTrue;
 import static melnorme.utilbox.core.CoreUtil.downCast;
+
 import melnorme.utilbox.misc.NumberUtil;
 
 

--- a/plugin_tooling/src-lang/melnorme/lang/tooling/structure/AbstractStructureContainer.java
+++ b/plugin_tooling/src-lang/melnorme/lang/tooling/structure/AbstractStructureContainer.java
@@ -14,9 +14,11 @@ import static melnorme.utilbox.core.Assert.AssertNamespace.assertTrue;
 import static melnorme.utilbox.core.CoreUtil.areEqual;
 import static melnorme.utilbox.core.CoreUtil.nullToEmpty;
 
+import java.util.function.Consumer;
+
+import melnorme.utilbox.collections.ArrayList2;
 import melnorme.utilbox.collections.Indexable;
 import melnorme.utilbox.misc.HashcodeUtil;
-
 
 public abstract class AbstractStructureContainer implements IStructureElementContainer {
 	
@@ -43,7 +45,21 @@ public abstract class AbstractStructureContainer implements IStructureElementCon
 		return children;
 	}
 	
-	/* -----------------  ----------------- */
+	public Indexable<StructureElement> cloneSubTree() {
+		ArrayList2<StructureElement> clonedElements = new ArrayList2<>(children.size());
+		for(StructureElement child : children) {
+			clonedElements.add(child.cloneTree());
+		}
+		return clonedElements;
+	}
+	
+	public void visitSubTree(Consumer<StructureElement> visitor) {
+		for(StructureElement child : getChildren()) {
+			child.visitTree(visitor);
+		}
+	}
+	
+	/* ----------------- ----------------- */
 	
 	public static class SimpleStructureContainer extends AbstractStructureContainer {
 		

--- a/plugin_tooling/src-lang/melnorme/lang/tooling/structure/ISourceFileStructure.java
+++ b/plugin_tooling/src-lang/melnorme/lang/tooling/structure/ISourceFileStructure.java
@@ -10,15 +10,16 @@
  *******************************************************************************/
 package melnorme.lang.tooling.structure;
 
-import melnorme.utilbox.misc.Location;
+import java.util.Optional;
 
+import melnorme.utilbox.misc.Location;
 
 public interface ISourceFileStructure extends IStructureElementContainer {
 	
-	/** @return the location of this SourceFile. Can be null */
-	Location getLocation();
+	/** @return the location of this SourceFile */
+	Optional<Location> getLocation();
 	
-//	@Override
+	//	@Override
 	String getModuleName();
 	
 }

--- a/plugin_tooling/src-lang/melnorme/lang/tooling/structure/IStructureElement.java
+++ b/plugin_tooling/src-lang/melnorme/lang/tooling/structure/IStructureElement.java
@@ -16,7 +16,6 @@ import melnorme.lang.tooling.ElementAttributes;
 import melnorme.lang.tooling.ast.SourceRange;
 import melnorme.utilbox.misc.Location;
 
-
 /**
  * A structure element is a lightweight structure describing a top-level element 
  * obtained from a source file (compilation unit).
@@ -52,14 +51,13 @@ public interface IStructureElement extends IStructureElementContainer {
 	/** @return the containing {@link ISourceFileStructure} of this element. Can be null. */
 	ISourceFileStructure getContainingFileStructure();
 	
-	
 	/** @return the optional Location of this structure element. */
 	default Optional<Location> getLocation() {
 		ISourceFileStructure containingFileStructure = getContainingFileStructure();
 		if(containingFileStructure == null) {
 			return Optional.empty();
 		}
-		return Optional.ofNullable(containingFileStructure.getLocation());
+		return containingFileStructure.getLocation();
 	}
 	
 }

--- a/plugin_tooling/src-lang/melnorme/lang/tooling/structure/SourceFileStructure_Default.java
+++ b/plugin_tooling/src-lang/melnorme/lang/tooling/structure/SourceFileStructure_Default.java
@@ -14,6 +14,8 @@ import static melnorme.utilbox.core.Assert.AssertNamespace.assertNotNull;
 import static melnorme.utilbox.core.CoreUtil.areEqual;
 import static melnorme.utilbox.core.CoreUtil.nullToEmpty;
 
+import java.util.Optional;
+
 import melnorme.lang.tooling.common.ParserError;
 import melnorme.utilbox.collections.Indexable;
 import melnorme.utilbox.misc.HashcodeUtil;
@@ -56,8 +58,8 @@ public abstract class SourceFileStructure_Default extends AbstractStructureConta
 	/* -----------------  ----------------- */
 	
 	@Override
-	public Location getLocation() {
-		return location;
+	public Optional<Location> getLocation() {
+		return Optional.ofNullable(location);
 	}
 	
 	@Override

--- a/plugin_tooling/src-lang/melnorme/lang/tooling/structure/StructureElement_Default.java
+++ b/plugin_tooling/src-lang/melnorme/lang/tooling/structure/StructureElement_Default.java
@@ -80,15 +80,10 @@ abstract class StructureElement_Default extends AbstractStructureContainer imple
 		return "ELEM " + name + sourceRange + " " + elementKind + prefixStr(" : ", type) + " " + elementAttributes;
 	}
 	
-	public StructureElement cloneSubTree() {
-		return new StructureElement(name, nameSourceRange2, sourceRange, 
-			elementKind, elementAttributes, type, cloneSubTree(children));
-	}
-	
 	public static ArrayList2<StructureElement> cloneSubTree(Indexable<StructureElement> elements) {
 		ArrayList2<StructureElement> clonedElements = new ArrayList2<>(elements.size());
-		for (StructureElement child : elements) {
-			clonedElements.add(child.cloneSubTree());
+		for(StructureElement child : elements) {
+			clonedElements.add(child.cloneTree());
 		}
 		return clonedElements;
 	}
@@ -139,12 +134,6 @@ abstract class StructureElement_Default extends AbstractStructureContainer imple
 		this.parent = parent;
 	}
 	
-//	@Override
-//	public String getModuleName() {
-//		IStructureElementContainer parent = getParent();
-//		return parent == null ? null : parent.getModuleName();
-//	}
-	
 	@Override
 	public ISourceFileStructure getContainingFileStructure() {
 		return getFileStructure(this);
@@ -155,7 +144,7 @@ abstract class StructureElement_Default extends AbstractStructureContainer imple
 		
 		if(parent instanceof ISourceFileStructure) {
 			return (ISourceFileStructure) parent;
-		} else if (parent instanceof IStructureElement) {
+		} else if(parent instanceof IStructureElement) {
 			return getFileStructure((IStructureElement) parent);
 		} else {
 			return null;

--- a/plugin_tooling/src-lang/melnorme/lang/tooling/toolchain/ops/SourceOpContext.java
+++ b/plugin_tooling/src-lang/melnorme/lang/tooling/toolchain/ops/SourceOpContext.java
@@ -16,7 +16,6 @@ import static melnorme.utilbox.core.CoreUtil.areEqual;
 import java.util.Optional;
 
 import melnorme.lang.tooling.ast.SourceRange;
-import melnorme.lang.tooling.common.SourceLineColumnRange;
 import melnorme.lang.tooling.parser.SourceLinesInfo;
 import melnorme.utilbox.core.CommonException;
 import melnorme.utilbox.misc.FileUtil;
@@ -109,13 +108,4 @@ public class SourceOpContext {
 		// TODO: we might need to do auto-detect of encoding.
 		return FileUtil.readFileContents(location, StringUtil.UTF8);
 	}
-	
-	public int getOffsetFor(SourceLocation findDefResult) throws CommonException {
-		String fileContents = getSourceFor(findDefResult.getFileLocation());
-		SourceLinesInfo linesInfo = new SourceLinesInfo(fileContents);
-		
-		SourceLineColumnRange sourceLCRange = findDefResult.getSourceRange();
-		return linesInfo.getOffsetForLine(sourceLCRange.getValidLineIndex()) + sourceLCRange.getValidColumnIndex();
-	}
-	
 }

--- a/plugin_tooling/src-lang/melnorme/lang/tooling/toolchain/ops/ToolOutputParseHelper.java
+++ b/plugin_tooling/src-lang/melnorme/lang/tooling/toolchain/ops/ToolOutputParseHelper.java
@@ -13,7 +13,6 @@ package melnorme.lang.tooling.toolchain.ops;
 import java.nio.file.Path;
 
 import melnorme.lang.tooling.common.LineColumnPosition;
-import melnorme.lang.tooling.common.SourceLineColumnRange;
 import melnorme.utilbox.core.CommonException;
 import melnorme.utilbox.misc.Location;
 import melnorme.utilbox.misc.MiscUtil;
@@ -42,16 +41,6 @@ public interface ToolOutputParseHelper {
 	
 	default Location parseLocation(String pathString) throws CommonException {
 		return Location.create(pathString);
-	}
-	
-	public static SourceLocation parsePathLineColumn(String sourceString, String separator) 
-			throws CommonException {
-		
-		Pair<String, LineColumnPosition> pair = parsePathLineColumn2(sourceString, separator);
-		Location loc = Location.create(pair.getFirst());
-		LineColumnPosition lcPos = pair.getSecond();
-		
-		return new SourceLocation(loc, new SourceLineColumnRange(lcPos.line, lcPos.column));
 	}
 	
 	/**

--- a/plugin_tooling/src-lang/melnorme/lang/utils/concurrency/ConcurrentlyDerivedData.java
+++ b/plugin_tooling/src-lang/melnorme/lang/utils/concurrency/ConcurrentlyDerivedData.java
@@ -162,10 +162,13 @@ public class ConcurrentlyDerivedData<DATA, SELF> {
 			}
 		}
 		
+		public void awaitUpdatedData() throws InterruptedException {
+			derivedData.awaitUpdatedData();
+		}
+		
 		protected abstract void handleRuntimeException(RuntimeException e);
 		
 		protected abstract DATA createNewData() throws OperationCancellation;
-		
 	}
 	
 	/* -----------------  ----------------- */

--- a/plugin_tooling/src/com/github/rustdt/tooling/ops/RacerCompletionOutputParser.java
+++ b/plugin_tooling/src/com/github/rustdt/tooling/ops/RacerCompletionOutputParser.java
@@ -17,9 +17,7 @@ import melnorme.lang.tooling.ElementAttributes;
 import melnorme.lang.tooling.ToolCompletionProposal;
 import melnorme.lang.tooling.ToolingMessages;
 import melnorme.lang.tooling.ast.SourceRange;
-import melnorme.lang.tooling.common.SourceLineColumnRange;
 import melnorme.lang.tooling.toolchain.ops.AbstractToolResultParser;
-import melnorme.lang.tooling.toolchain.ops.SourceLocation;
 import melnorme.lang.tooling.toolchain.ops.ToolOutputParseHelper;
 import melnorme.lang.utils.parse.LexingUtils;
 import melnorme.lang.utils.parse.StringCharSource;
@@ -229,11 +227,11 @@ public abstract class RacerCompletionOutputParser extends AbstractToolResultPars
 	
 	/* ----------------- find-definition ----------------- */
 	
-	public SourceLocation parseResolvedMatch(String lineInput) throws CommonException {
+	public RacerCompletionResult parseResolvedMatch(String lineInput) throws CommonException {
 		return doParseResolvedMatch(lineInput);
 	}
 	
-	protected SourceLocation doParseResolvedMatch(String lineInput) throws CommonException {
+	private RacerCompletionResult doParseResolvedMatch(String lineInput) throws CommonException {
 		StringCharSource lineLexer = new StringCharSource(lineInput);
 		
 		if(lineLexer.tryConsume("MATCH ") == false) {
@@ -246,8 +244,7 @@ public abstract class RacerCompletionOutputParser extends AbstractToolResultPars
 		int column_0 = parsePositiveInt(consumeCommaDelimitedText(lineLexer));
 		Location loc = parseLocation(consumeCommaDelimitedText(lineLexer));
 		
-		SourceLineColumnRange position = new SourceLineColumnRange(line_1, column_0 + 1);
-		return new SourceLocation(loc, position);
+		return new RacerCompletionResult(loc, line_1, column_0 + 1);
 	}
 	
 }

--- a/plugin_tooling/src/com/github/rustdt/tooling/ops/RacerCompletionResult.java
+++ b/plugin_tooling/src/com/github/rustdt/tooling/ops/RacerCompletionResult.java
@@ -1,0 +1,17 @@
+package com.github.rustdt.tooling.ops;
+
+import melnorme.utilbox.misc.Location;
+
+public class RacerCompletionResult {
+	
+	public final Location location;
+	public final int oneBasedLineNumber;
+	public final int zeroBasedColumnNumber;
+	
+	public RacerCompletionResult(Location location, int oneBasedLineNumber, int zeroBasedColumnNumber) {
+		this.location = location;
+		this.oneBasedLineNumber = oneBasedLineNumber;
+		this.zeroBasedColumnNumber = zeroBasedColumnNumber;
+	}
+	
+}

--- a/plugin_tooling/src/com/github/rustdt/tooling/ops/RacerFindDefinitionOperation.java
+++ b/plugin_tooling/src/com/github/rustdt/tooling/ops/RacerFindDefinitionOperation.java
@@ -13,7 +13,6 @@ package com.github.rustdt.tooling.ops;
 import java.nio.file.Path;
 
 import melnorme.lang.tooling.toolchain.ops.IToolOperationService;
-import melnorme.lang.tooling.toolchain.ops.SourceLocation;
 import melnorme.lang.tooling.toolchain.ops.SourceOpContext;
 import melnorme.lang.utils.parse.StringCharSource;
 import melnorme.utilbox.collections.Indexable;
@@ -21,7 +20,7 @@ import melnorme.utilbox.core.CommonException;
 import melnorme.utilbox.fields.validation.ValidatedValueSource;
 import melnorme.utilbox.misc.Location;
 
-public class RacerFindDefinitionOperation extends RacerOperation<SourceLocation> {
+public class RacerFindDefinitionOperation extends RacerOperation<RacerCompletionResult> {
 	
 	protected final int offset;
 	
@@ -41,7 +40,7 @@ public class RacerFindDefinitionOperation extends RacerOperation<SourceLocation>
 	}
 	
 	@Override
-	public SourceLocation parseOutput(StringCharSource output) throws CommonException {
+	public RacerCompletionResult parseOutput(StringCharSource output) throws CommonException {
 		return createRacerOutputParser(offset).parseResolvedMatch(output.getSource());
 	}
 	

--- a/plugin_tooling/src/melnorme/lang/tooling/structure/GlobalSourceStructure.java
+++ b/plugin_tooling/src/melnorme/lang/tooling/structure/GlobalSourceStructure.java
@@ -1,0 +1,59 @@
+package melnorme.lang.tooling.structure;
+
+import static java.util.Comparator.comparing;
+import static melnorme.utilbox.core.Assert.AssertNamespace.assertTrue;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import melnorme.utilbox.misc.Location;
+
+public class GlobalSourceStructure {
+	private static final EnumSet<StructureElementKind> HIDDEN_ELEMENT_KINDS = EnumSet.of(
+		StructureElementKind.EXTERN_CRATE, StructureElementKind.USE_GROUP, StructureElementKind.USE,
+		StructureElementKind.VAR);
+	
+	private final SortedMap<Location, SortedSet<StructureElement>> index = new TreeMap<>(comparing(Location::toPath));
+	
+	public synchronized void updateIndex(SourceFileStructure fileStructure) {
+		Optional<Location> location = fileStructure.getLocation();
+		assertTrue(location.isPresent(), "Location is missing");
+		
+		if(fileStructure.getChildren().isEmpty()) {
+			removeFromIndex(location.get());
+		} else {
+			putToIndex(fileStructure, location.get());
+		}
+	}
+	
+	private void removeFromIndex(Location location) {
+		index.remove(location);
+	}
+	
+	private void putToIndex(SourceFileStructure fileStructure, Location location) {
+		SortedSet<StructureElement> elementsAtLocation =
+			new TreeSet<>(comparing(StructureElement::getName).thenComparing(StructureElement::getSourceRange));
+		
+		fileStructure.visitSubTree(el -> {
+			if(!HIDDEN_ELEMENT_KINDS.contains(el.getKind())) {
+				elementsAtLocation.add(el);
+			}
+		});
+		
+		index.put(location, elementsAtLocation);
+	}
+	
+	public synchronized List<StructureElement> getGlobalSourceStructure() {
+		return index.values()
+			.stream()
+			.flatMap(Set::stream)
+			.collect(Collectors.toList());
+	};
+}

--- a/plugin_tooling/src/melnorme/lang/tooling/structure/StructureElement.java
+++ b/plugin_tooling/src/melnorme/lang/tooling/structure/StructureElement.java
@@ -10,11 +10,12 @@
  *******************************************************************************/
 package melnorme.lang.tooling.structure;
 
+import java.util.function.Consumer;
+
 import melnorme.lang.tooling.ElementAttributes;
 import melnorme.lang.tooling.LANG_SPECIFIC;
 import melnorme.lang.tooling.ast.SourceRange;
 import melnorme.utilbox.collections.Indexable;
-
 
 @LANG_SPECIFIC
 public class StructureElement extends StructureElement_Default {
@@ -25,4 +26,17 @@ public class StructureElement extends StructureElement_Default {
 		super(name, nameSourceRange, sourceRange, elementKind, elementAttributes, type, children);
 	}
 	
+	public StructureElement cloneTree() {
+		return cloneWithChildren(cloneSubTree());
+	}
+	
+	public void visitTree(Consumer<StructureElement> visitor) {
+		visitor.accept(this);
+		visitSubTree(visitor);
+	}
+	
+	private StructureElement cloneWithChildren(Indexable<StructureElement> children) {
+		return new StructureElement(
+			name, nameSourceRange2, sourceRange, elementKind, elementAttributes, type, children);
+	}
 }


### PR DESCRIPTION
I played around with the new index. Turned out that some new cool things can be done using it!

One of those things on my agenda was to fix the problem that Racer often does not find any result, e.g. because an element is not visible from the root of the source tree. This PR solves most of the issues related to that problem.

Content of this PR:
- If Racer fails to find a definition the corresponding element is searched using the index instead.
- If there is more than one result the user can pick the desired location.
- The index now outputs the location and not the type signature any more.
- The index matching performance has been improved.

This PR is quite big as it builds up on my Open_Type branch which is not merged yet.
